### PR TITLE
Support connection timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionK
 }
 ```
 
+### connectionTimeout
+
+Unofortunately, the underlying Zookeeper Library does not signal when the attempt to connect has resulted in an error. Instead, the library will continue to try to reconnect indefinitely. This will cancel attempts to connect after a given period of time.
+
+*Default:* 2000
+
 ## Activation
 
 As well as uploading a file to Zookeeper, *ember-cli-deploy-zookeeper* has the ability to mark a revision of a deployed file as `current`. This is most commonly used in the [lightning method of deployment][1] whereby an index.html file is pushed to Zookeeper and then served to the user by a web server. The web server could be configured to return any existing revision of the index.html file as requested by a query parameter. However, the revision marked as the currently `active` revision would be returned if no query paramter is present. For more detailed information on this method of deployment please refer to the [ember-cli-deploy-lightning-pack README][1].

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
         host: 'localhost',
         port: 2181,
         files: ['index.html'],
+        connectionTimeout: 2000,
         distDir: function(context) {
           return context.distDir;
         },

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -9,7 +9,7 @@ module.exports = CoreObject.extend({
 
     this.client = new zkLib(options);
     this._createPromisesHash = {};
-    this.connection = this.client.connect();
+    this.connection = this.connect(options.connectionTimeout || 10000);
   },
   get: proxyMethod('get'),
   getChildren: proxyMethod('getChildren'),
@@ -48,6 +48,22 @@ module.exports = CoreObject.extend({
       }
 
       return _createPromisesHash[key];
+    });
+  },
+
+  connect: function(connectionTimeout) {
+    var client = this.client;
+    var timeout;
+
+    return new Promise(function(resolve, reject) {
+      var timeout = setTimeout(reject, connectionTimeout, 'Connection to Zookeeper timed out');
+      client.connect().then(function(res) {
+        clearTimeout(timeout);
+        resolve(res);
+      });
+    }).catch( function(err) {
+      client.close();
+      return Promise.reject(err);
     });
   }
 });

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -10,6 +10,7 @@ module.exports = CoreObject.extend({
     this._client = new zkProxy({
       host: options.host,
       port: options.port,
+      connectionTimeout: options.connectionTimeout,
       timeout: 1000
     }, lib);
 

--- a/tests/helpers/fake-zk-client.js
+++ b/tests/helpers/fake-zk-client.js
@@ -59,7 +59,7 @@ module.exports = CoreObject.extend({
     } else {
       this._hash[path] = data;
       return new Promise(function(resolve) {
-        setTimeout(resolve, { stat: {} }, 10);
+        setTimeout(resolve, 1, { stat: {} });
       });
     }
   },

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -199,7 +199,7 @@ describe('zookeeper index', function() {
           return previous;
         }, []);
 
-        assert.equal(messages.length, 8);
+        assert.equal(messages.length, 9);
       });
 
       it('adds default config to the config object', function() {
@@ -208,6 +208,7 @@ describe('zookeeper index', function() {
         assert.isDefined(config.zookeeper.port);
         assert.isDefined(config.zookeeper.keyPrefix);
         assert.isDefined(config.zookeeper.didDeployMessage);
+        assert.isDefined(config.zookeeper.connectionTimeout);
       });
     });
 
@@ -238,7 +239,7 @@ describe('zookeeper index', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 7);
+        assert.equal(messages.length, 8);
       });
       it('does not add default config to the config object', function() {
         plugin.configure(context);

--- a/tests/unit/lib/zookeeper-proxy-nodetest.js
+++ b/tests/unit/lib/zookeeper-proxy-nodetest.js
@@ -152,3 +152,27 @@ describe('zookeeper proxy', function() {
     });
   });
 });
+
+describe('zookeeper proxy: connection errors', function() {
+  it('closes connections with error after specified timeout', function() {
+    var closeWasCalled = false;
+    var stub = ClientStub.extend({
+      connect: function() {
+        // A never resolving promise.
+        return new Promise(function() {});
+      },
+      close: function() {
+        closeWasCalled = true;
+        return Promise.resolve('close');
+      }
+    });
+    var proxy = new ZookeeperProxy({
+      connectionTimeout: 5
+    }, stub);
+
+    return proxy.connection.catch(function(err) {
+      assert.equal(err, 'Connection to Zookeeper timed out');
+      assert.ok(closeWasCalled);
+    });
+  });
+});


### PR DESCRIPTION
Per this issue, the Zookeeper Client does not have access to connection errors. 

https://github.com/yfinkelstein/node-zookeeper/pull/96/files

This pr makes sure we can close attempts to connect after a given timeout. 
