### PR TITLE
get timestamps for revisions

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -74,20 +74,32 @@ module.exports = CoreObject.extend({
       .then(function(results) {
         var current = results.current;
         return results.revisions.map(function(revision) {
-          return {
-            revision: revision,
-            active: current ? revision === current : false
-          };
+          revision.active = current ? revision.revision === current : false;
+          return revision;
         });
       });
   },
 
   _listRevisions: function(keyPrefix) {
     var path = makePath(keyPrefix, REVISION_PATH);
+    var self = this;
     return Promise.resolve()
       .then(this._client.getChildren.bind(this._client, path))
       .then(function(res) {
-        return res.children;
+        return Promise.all(res.children.map(function(revision) {
+          return self._getRevisionData(keyPrefix, revision);
+        }));
+      });
+  },
+  _getRevisionData: function(keyPrefix, revision) {
+    var path = makePath(keyPrefix, REVISION_PATH, revision);
+    return Promise.resolve()
+      .then(this._client.get.bind(this._client, path))
+      .then(function(res) {
+        return {
+          revision: revision,
+          timestamp: parseInt(res.data.toString(), 10)
+        };
       });
   },
   _createMissingParentPaths: function(parts) {
@@ -189,7 +201,10 @@ module.exports = CoreObject.extend({
     });
   },
   _validateRevisionKey: function(revisionKey, revisions) {
-    return revisions.indexOf(revisionKey) > -1 ? Promise.resolve() : Promise.reject('`' + revisionKey + '` is not a valid revision key');
+    var revisionsList = revisions.map(function(revision) {
+      return revision.revision;
+    });
+    return revisionsList.indexOf(revisionKey) > -1 ? Promise.resolve() : Promise.reject('`' + revisionKey + '` is not a valid revision key');
   },
   _activateRevisionKey: function(keyPrefix, revision) {
     var path = makePath(keyPrefix);

--- a/tests/unit/lib/zookeeper-nodetest.js
+++ b/tests/unit/lib/zookeeper-nodetest.js
@@ -236,9 +236,9 @@ describe('zookeeper plugin', function() {
     it('lists the last existing revisions', function() {
       var zk = new Zookeeper({}, FakeZookeeper);
       zk._client.client._hash = {
-        '/key/revisions/1': 1,
-        '/key/revisions/2': 2,
-        '/key/revisions/3': 3
+        '/key/revisions/1': '1',
+        '/key/revisions/2': '2',
+        '/key/revisions/3': '3'
       };
 
       var promise = zk.fetchRevisions('key');
@@ -247,15 +247,18 @@ describe('zookeeper plugin', function() {
           assert.deepEqual(result, [
             {
               revision: '1',
-              active: false
+              active: false,
+              timestamp: 1
             },
             {
               revision: '2',
-              active: false
+              active: false,
+              timestamp: 2
             },
             {
               revision: '3',
-              active: false
+              active: false,
+              timestamp: 3
             }
           ]);
         });
@@ -265,9 +268,9 @@ describe('zookeeper plugin', function() {
       var zk = new Zookeeper({}, FakeZookeeper);
       zk._client.client._hash = {
         '/key': '2',
-        '/key/revisions/1': 1,
-        '/key/revisions/2': 2,
-        '/key/revisions/3': 3
+        '/key/revisions/1': '1',
+        '/key/revisions/2': '2',
+        '/key/revisions/3': '3'
       };
 
       var promise = zk.fetchRevisions('key');
@@ -276,15 +279,18 @@ describe('zookeeper plugin', function() {
           assert.deepEqual(result, [
             {
               revision: '1',
-              active: false
+              active: false,
+              timestamp: 1
             },
             {
               revision: '2',
-              active: true
+              active: true,
+              timestamp: 2
             },
             {
               revision: '3',
-              active: false
+              active: false,
+              timestamp: 3
             }
           ]);
         });


### PR DESCRIPTION
Let's make sure that when listing revisions, we get timestamp data for when it was deployed. 
