### PR TITLE
close after each hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = {
         var zkDeployClient = this.readConfig('zookeeperDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
         this.log('Validating presence of required paths for `' + keyPrefix + '`');
+
         return zkDeployClient.willDeploy(keyPrefix);
       },
 

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -11,7 +11,6 @@ module.exports = CoreObject.extend({
     this.client = new zkLib(options);
     this.options = options;
     this._createPromisesHash = {};
-    // this.connection = this.connect(options.connectionTimeout || 10000);
   },
   get: proxyMethod('get'),
   getChildren: proxyMethod('getChildren'),

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -9,8 +9,9 @@ module.exports = CoreObject.extend({
     }
 
     this.client = new zkLib(options);
+    this.options = options;
     this._createPromisesHash = {};
-    this.connection = this.connect(options.connectionTimeout || 10000);
+    // this.connection = this.connect(options.connectionTimeout || 10000);
   },
   get: proxyMethod('get'),
   getChildren: proxyMethod('getChildren'),
@@ -37,26 +38,33 @@ module.exports = CoreObject.extend({
     var client = this.client;
     var _createPromisesHash = this._createPromisesHash;
 
-    return client.exists(key).then(function(res) {
-      if (res.stat) {
-        return;
-      }
+    return this.connect()
+      .then(client.exists.bind(client, key))
+      .then(function(res) {
+        if (res.stat) {
+          return;
+        }
 
-      // If it doesn't exist, memoize the actual creation
-      // so that this request to create can only happen once.
-      if (!(key in _createPromisesHash)) {
-        _createPromisesHash[key] = client.create(key);
-      }
+        // If it doesn't exist, memoize the actual creation
+        // so that this request to create can only happen once.
+        if (!(key in _createPromisesHash)) {
+          _createPromisesHash[key] = client.create(key);
+        }
 
-      return _createPromisesHash[key];
-    });
+        return _createPromisesHash[key];
+      });
   },
 
-  connect: function(connectionTimeout) {
+  connect: function() {
+    var connectionTimeout = this.options.connectionTimeout || 10000;
     var client = this.client;
     var timeout;
 
-    return new Promise(function(resolve, reject) {
+    if (this.connection) {
+      return this.connection;
+    }
+
+    this.connection = new Promise(function(resolve, reject) {
       var timeout = setTimeout(reject, connectionTimeout, 'Connection to Zookeeper timed out');
       client.connect().then(function(res) {
         clearTimeout(timeout);
@@ -66,6 +74,13 @@ module.exports = CoreObject.extend({
       client.close();
       return Promise.reject(err);
     });
+
+    return this.connection;
+  },
+
+  disconnect: function() {
+    this.connection = null;
+    this.client.close();
   }
 });
 
@@ -76,7 +91,8 @@ function proxyMethod(/* methodName, ...additionalArgs */) {
     var args = Array.prototype.slice.apply(arguments);
     var allArgs = args.concat(outerArgs);
     var client = this.client;
-    return this.connection
+
+    return this.connect()
       .then(function() {
         return client[methodName].apply(client, allArgs);
       })

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -16,11 +16,13 @@ module.exports = CoreObject.extend({
     this._maxNumberOfRecentUploads = 10;
     this._allowOverwrite = !!options.allowOverwrite;
   },
-  willDeploy: function(keyPrefix) {
+
+  willDeploy: disconnectAfter(function(keyPrefix) {
     // Make sure that the /keyPrefix/revision path exists
     return this._createMissingParentPaths([keyPrefix, REVISION_PATH]);
-  },
-  upload: function(/*keyPrefix, revisionKey, fileName, value*/) {
+  }),
+
+  upload: disconnectAfter(function(/*keyPrefix, revisionKey, fileName, value*/) {
     // Upload the file to the specified key, given the revision number
     var args = Array.prototype.slice.call(arguments);
     var keyPrefix = args.shift();
@@ -40,34 +42,32 @@ module.exports = CoreObject.extend({
       .then(function() {
         return zkKey;
       });
-  },
-  activate: function(keyPrefix, revisionKey) {
+  }),
+
+  activate: disconnectAfter(function(keyPrefix, revisionKey) {
     return Promise.resolve()
       .then(this._listRevisions.bind(this, keyPrefix))
       .then(this._validateRevisionKey.bind(this, revisionKey))
       .then(this._activateRevisionKey.bind(this, keyPrefix, revisionKey))
-      .then(this.activeRevision.bind(this, keyPrefix));
-  },
-  activeRevision: function(keyPrefix) {
-    var path = makePath(keyPrefix);
-    var client = this._client;
-    return Promise.resolve()
-      .then(function() {
-        return client.get(path);
-      })
-      .then(function(result) {
-        return result.data;
-      });
-  },
+      .then(this._activeRevision.bind(this, keyPrefix));
+  }),
 
-  fetchRevisions: function(keyPrefix) {
+  activeRevision: disconnectAfter(function(keyPrefix) {
+    return this._activeRevision(keyPrefix);
+  }),
+
+  fetchRevisions: disconnectAfter(function(keyPrefix) {
+    return this._fetchRevisions(keyPrefix);
+  }),
+
+  _fetchRevisions: function(keyPrefix) {
     var self = this;
     var client = this._client;
     return Promise.resolve()
       .then(function() {
         return Promise.hash({
           revisions: self._listRevisions(keyPrefix),
-          current: self.activeRevision(keyPrefix)
+          current: self._activeRevision(keyPrefix)
         });
       })
       .then(function(results) {
@@ -76,6 +76,18 @@ module.exports = CoreObject.extend({
           revision.active = current ? revision.revision === current : false;
           return revision;
         });
+      });
+  },
+
+  _activeRevision: function(keyPrefix) {
+    var path = makePath(keyPrefix);
+    var client = this._client;
+    return Promise.resolve()
+      .then(function() {
+        return client.get(path);
+      })
+      .then(function(result) {
+        return result.data;
       });
   },
 
@@ -167,7 +179,7 @@ module.exports = CoreObject.extend({
   _trimRecentUploadsList: function(keyPrefix, maxEntries) {
     var client = this._client;
     var self = this;
-    return this.fetchRevisions(keyPrefix).then(function(results) {
+    return this._fetchRevisions(keyPrefix).then(function(results) {
       // Get all the revisions.
       return Promise.all(results.filter(function(revision) {
         return !revision.active;
@@ -208,6 +220,19 @@ module.exports = CoreObject.extend({
     return this._client.set(path, revision);
   }
 });
+
+function disconnectAfter(cb) {
+  return function() {
+    var client = this._client;
+    var result = cb.apply(this, arguments);
+
+    result.finally(function() {
+      client.disconnect();
+    });
+
+    return result;
+  };
+}
 
 function makePath(/* args */) {
   var args = Array.prototype.slice.call(arguments);

--- a/tests/helpers/fake-zk-client.js
+++ b/tests/helpers/fake-zk-client.js
@@ -84,6 +84,8 @@ module.exports = CoreObject.extend({
     if (!this.isConnected) {
       return this._notConnectedErr();
     }
+
+    this.isConnected = false;
     return Promise.resolve();
   },
   getChildren: function(path) {

--- a/tests/unit/lib/zookeeper-nodetest.js
+++ b/tests/unit/lib/zookeeper-nodetest.js
@@ -26,9 +26,11 @@ describe('zookeeper plugin', function() {
       var zk = new Zookeeper({}, FakeZookeeper);
 
       var promise = zk.upload('key', 'index.html', 'value');
+
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok('/key/default/index.html' in zk._client.client._hash);
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
 
@@ -58,6 +60,7 @@ describe('zookeeper plugin', function() {
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok('/key/default/index.html' in zk._client.client._hash);
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
 
@@ -179,6 +182,7 @@ describe('zookeeper plugin', function() {
         .then(function() {
           assert.ok('/key' in zk._client.client._hash);
           assert.ok('/key/revisions' in zk._client.client._hash);
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
   });
@@ -194,6 +198,7 @@ describe('zookeeper plugin', function() {
       return assert.isFulfilled(promise)
         .then(function(revision) {
           assert.equal(revision, '1');
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
   });
@@ -212,6 +217,7 @@ describe('zookeeper plugin', function() {
       return assert.isRejected(promise)
         .then(function(error) {
           assert.equal(error, '`notme` is not a valid revision key');
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
 
@@ -228,6 +234,7 @@ describe('zookeeper plugin', function() {
       return assert.isFulfilled(promise)
         .then(function(activatedKey) {
           assert.equal(activatedKey, '2');
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
         });
     });
   });
@@ -244,6 +251,7 @@ describe('zookeeper plugin', function() {
       var promise = zk.fetchRevisions('key');
       return assert.isFulfilled(promise)
         .then(function(result) {
+          assert.ok(!zk._client.connection); // Make sure the connection is closed afterwards
           assert.deepEqual(result, [
             {
               revision: '1',

--- a/tests/unit/lib/zookeeper-proxy-nodetest.js
+++ b/tests/unit/lib/zookeeper-proxy-nodetest.js
@@ -170,7 +170,7 @@ describe('zookeeper proxy: connection errors', function() {
       connectionTimeout: 5
     }, stub);
 
-    return proxy.connection.catch(function(err) {
+    return proxy.connect().catch(function(err) {
       assert.equal(err, 'Connection to Zookeeper timed out');
       assert.ok(closeWasCalled);
     });


### PR DESCRIPTION
This will make sure that the connection is closed after each of the hooks to prevent Zookeeper from getting too annoyed about long-unused connections.
