### PR TITLE
Use zookeeper not zk

### DIFF
--- a/lib/zookeeper-error.js
+++ b/lib/zookeeper-error.js
@@ -44,7 +44,6 @@ var ZkError = function (code, message, path) {
     }
 
     this.message = _messages[code] || message || 'ZooKeeper Error';
-    console.log(this.stack);
 };
 
 ZkError.prototype = Object.create(Error.prototype);

--- a/lib/zookeeper-error.js
+++ b/lib/zookeeper-error.js
@@ -1,0 +1,81 @@
+// Borrowed from: https://github.com/oleksiyk/zk/blob/master/lib/error.js
+'use strict';
+
+var _ = require('lodash');
+
+var _messages = {
+    '-1'   : 'System error',
+    '-2'   : 'A runtime inconsistency was found',
+    '-3'   : 'A data inconsistency was found',
+    '-4'   : 'Connection to the server has been lost',
+    '-5'   : 'Error while marshalling or unmarshalling data',
+    '-6'   : 'Operation is unimplemented',
+    '-7'   : 'Operation timeout',
+    '-8'   : 'Invalid arguments',
+    '-9'   : 'Invliad zhandle state',
+    '-100' : 'API Error',
+    '-101' : 'Node does not exist',
+    '-102' : 'Not authenticated',
+    '-103' : 'Version conflict',
+    '-108' : 'Ephemeral nodes may not have children',
+    '-110' : 'The node already exists',
+    '-111' : 'The node has children',
+    '-112' : 'The session has been expired by the server',
+    '-113' : 'Invalid callback specified',
+    '-114' : 'Invalid ACL specified',
+    '-115' : 'Client authentication failed',
+    '-116' : 'ZooKeeper is closing',
+    '-117' : '(not error) no server responses to process',
+    '-118' : 'session moved to another server, so operation is ignored',
+    '-120' : 'No quorum of new config is connected and up-to-date with the leader of last commmitted config - try invoking reconfiguration after new servers are connected and synced',
+    '-121' : 'Reconfiguration requested while another reconfiguration is currently in progress. This is currently not supported. Please retry.',
+    '-122' : 'Attempt to create ephemeral node on a local session',
+};
+
+var ZkError = function (code, message, path) {
+    Error.call(this);
+    Error.captureStackTrace(this, this.constructor); // capture the stack trace: http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+
+    this.name = _.findKey(exports, function (v) { return v === code; }) || 'ZkError';
+
+    this.code = code;
+    if (path) {
+        this.path = path;
+    }
+
+    this.message = _messages[code] || message || 'ZooKeeper Error';
+    console.log(this.stack);
+};
+
+ZkError.prototype = Object.create(Error.prototype);
+ZkError.prototype.constructor = ZkError;
+
+exports = module.exports = ZkError;
+
+exports.ZOK = 0;
+exports.ZSYSTEMERROR = -1;
+exports.ZRUNTIMEINCONSISTENCY = -2;
+exports.ZDATAINCONSISTENCY = -3;
+exports.ZCONNECTIONLOSS = -4;
+exports.ZMARSHALLINGERROR = -5;
+exports.ZUNIMPLEMENTED = -6;
+exports.ZOPERATIONTIMEOUT = -7;
+exports.ZBADARGUMENTS = -8;
+exports.ZINVALIDSTATE = -9;
+exports.ZAPIERROR = -100;
+exports.ZNONODE = -101;
+exports.ZNOAUTH = -102;
+exports.ZBADVERSION = -103;
+exports.ZNOCHILDRENFOREPHEMERALS = -108;
+exports.ZNODEEXISTS = -110;
+exports.ZNOTEMPTY = -111;
+exports.ZSESSIONEXPIRED = -112;
+exports.ZINVALIDCALLBACK = -113;
+exports.ZINVALIDACL = -114;
+exports.ZAUTHFAILED = -115;
+exports.ZCLOSING = -116;
+exports.ZNOTHING = -117;
+exports.ZSESSIONMOVED = -118;
+exports.ZNEWCONFIGNOQUORUM = -120;
+exports.ZRECONFIGINPROGRESS = -121;
+exports.ZEPHEMERALONLOCALSESSION = -122;

--- a/lib/zookeeper-promised.js
+++ b/lib/zookeeper-promised.js
@@ -1,0 +1,161 @@
+var CoreObject = require('core-object');
+var Promise = require('ember-cli/lib/ext/promise');
+var ZKError = require('./zookeeper-error');
+
+module.exports = CoreObject.extend({
+  init: function(options, zkLib) {
+    this.zkLib = zkLib || require('zookeeper')
+    this.options = options;
+  },
+
+  establishConnection: function() {
+    var options = this.options;
+    var connectionTimeout = this.options.connectionTimeout || 10000;
+    var zk = new this.zkLib({
+      connect: options.connect,
+      timeout: options.timeout,
+      debug_level: this.zkLib,
+      host_order_deterministic: true
+    });
+
+    this.connection = new Promise(function(resolve, reject) {
+      var timeout = setTimeout(function() {
+        reject('Timed out trying to connect to ZooKeeper');
+      }, connectionTimeout);
+
+      zk.connect(function(err) {
+        // Clear the timeout.
+        clearTimeout(timeout);
+
+        if (err) {
+          // there was an error connecting; reject.
+          reject(err);
+        } else {
+          // Othwerwise, success!
+          resolve(zk);
+        }
+      });
+    });
+
+    // Listen for close connection events.
+    var self = this;
+    zk.on('close', function() {
+      // Remove the connection.
+      self.connection = null;
+    });
+  },
+
+  connect: function() {
+    if (!this.connection) {
+      this.establishConnection();
+    }
+
+    return this.connection;
+  },
+
+  close: function() {
+    var self = this;
+    return this._promisify(function(zk, resolve) {
+      zk.close();
+      resolve();
+      this.connection = null;
+      return 0;
+    });
+  },
+
+  get: function(path) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_get(path, null, function(rc, error, stat, data) {
+        // If there is an error of some sort.
+        if (rc !== 0) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        return resolve({
+          stat: stat,
+          data: data
+        });
+      });
+    });
+  },
+
+  exists: function(path) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_exists(path, null, function(rc, error, stat) {
+        if (rc !== 0 && rc !== ZKError.ZNONODE) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        return resolve({
+          stat: stat
+        });
+      });
+    });
+  },
+
+  set: function(path, data, version) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_set(path, data, version, function(rc, error, stat) {
+        if (rc !== 0) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        resolve({
+          stat: stat
+        });
+      });
+    });
+  },
+
+  create: function(path, data, flags) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_create(path, data, flags, function(rc, error, _path) {
+        if (rc !== 0) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        resolve(_path);
+      });
+    });
+  },
+
+  delete: function(path, version) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_delete_(path, version, function(rc, error) {
+        if (rc !== 0) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        resolve();
+      });
+    });
+  },
+
+  getChildren: function(path) {
+    return this._promisify(function(zk, resolve, reject) {
+      return zk.a_get_children(path, null, function(rc, error, children) {
+        if (rc !== 0) {
+          return reject(new ZKError(rc, error, path));
+        }
+
+        resolve({
+          children: children
+        });
+      });
+    });
+  },
+
+  _promisify(cb) {
+    var self = this;
+    return this.connect().then(function(zk) {
+      return new Promise(function(resolve, reject) {
+        var ret = cb.call(self, zk, resolve, reject);
+
+        // If it immediately returned with an error, reject.
+        if (ret !== ZKError.ZOK) {
+          reject(new ZKError(ret));
+        }
+      });
+    });
+  }
+});

--- a/lib/zookeeper-promised.js
+++ b/lib/zookeeper-promised.js
@@ -11,6 +11,7 @@ module.exports = CoreObject.extend({
   establishConnection: function() {
     var options = this.options;
     var connectionTimeout = this.options.connectionTimeout || 10000;
+
     var zk = new this.zkLib({
       connect: options.connect,
       timeout: options.timeout,

--- a/lib/zookeeper-promised.js
+++ b/lib/zookeeper-promised.js
@@ -146,7 +146,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _promisify(cb) {
+  _promisify: function(cb) {
     var self = this;
     return this.connect().then(function(zk) {
       return new Promise(function(resolve, reject) {

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -1,17 +1,11 @@
 var CoreObject = require('core-object');
 var Promise = require('ember-cli/lib/ext/promise');
+var ZKPromised = require('./zookeeper-promised');
 
 module.exports = CoreObject.extend({
   init: function(options, zkLib) {
-    if (!zkLib) {
-      zkLib = require('zk');;
-      options.logLevel = options.logLevel || zkLib.ZOO_LOG_LEVEL_ERROR;
-    }
-
-    options.timeout = options.timeout || 2000000;
-    this.client = new zkLib(options);
+    this.client = new ZKPromised(options, zkLib);
     this._createPromisesHash = {};
-    this.connection = this.connect(options.connectionTimeout || 10000);
   },
   get: proxyMethod('get'),
   getChildren: proxyMethod('getChildren'),
@@ -30,7 +24,7 @@ module.exports = CoreObject.extend({
       })
       .catch(function(err) {
         client.close();
-        return Promise.reject();
+        return Promise.reject(err);
       });
   },
 
@@ -53,31 +47,21 @@ module.exports = CoreObject.extend({
     });
   },
 
-  connect: function(connectionTimeout) {
-    var client = this.client;
-    var timeout;
-
-    return new Promise(function(resolve, reject) {
-      var timeout = setTimeout(reject, connectionTimeout, 'Connection to Zookeeper timed out');
-      client.connect().then(function(res) {
-        clearTimeout(timeout);
-        resolve(res);
-      });
-    }).catch( function(err) {
-      client.close();
-      return Promise.reject(err);
-    });
+  connect: function() {
+    return this.client.connect();
   }
 });
 
 function proxyMethod(/* methodName, ...additionalArgs */) {
   var outerArgs = Array.prototype.slice.apply(arguments);
   var methodName = outerArgs.shift();
+
   return function() {
     var args = Array.prototype.slice.apply(arguments);
     var allArgs = args.concat(outerArgs);
     var client = this.client;
-    return this.connection
+
+    return this.connect()
       .then(function() {
         return client[methodName].apply(client, allArgs);
       })

--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "lodash": "^4.6.1",
     "rsvp": "^3.2.1",
-    "zk": "^1.0.3"
+    "zookeeper": "^3.4.7-2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/helpers/fake-zk-client.js
+++ b/tests/helpers/fake-zk-client.js
@@ -67,7 +67,7 @@ module.exports = CoreObject.extend({
     }.bind(this), 'a_set');
   },
 
-  a_create(path, data, flags, cb) {
+  a_create: function(path, data, flags, cb) {
     return next(function() {
       if (!this.isConnected) {
         return this._notConnectedErr(cb);

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -10,7 +10,7 @@ var stubProject = {
   }
 };
 
-describe('zookeeper index', function() {
+describe('ember-cli-deploy-zookeeper', function() {
   var subject, mockUi;
 
   beforeEach(function() {

--- a/tests/unit/lib/zookeeper-nodetest.js
+++ b/tests/unit/lib/zookeeper-nodetest.js
@@ -24,7 +24,7 @@ describe('zookeeper plugin', function() {
       return assert.isRejected(promise, /^The node already exists/);
     });
 
-    it.only('uploads the contents if the key does not already exist', function() {
+    it('uploads the contents if the key does not already exist', function() {
       var hash;
       var zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
@@ -51,44 +51,76 @@ describe('zookeeper plugin', function() {
 
       return assert.isRejected(zk.testCreatingNodeTwice('/key'))
         .then(function(err) {
-          assert.equal(err.message, 'Node already exists');
+          assert.equal(err.message, 'The node already exists');
         });
     });
 
     it('uploads the contents if the key already exists but allowOverwrite is true', function() {
       var fileUploaded = false;
       var nodeCreated = false;
+      var hash;
       var zk = new Zookeeper({
         allowOverwrite: true
-      }, FakeZookeeper);
+      }, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          hash = this._hash;
+        }
+      }));
 
       var promise = zk.upload('key', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
-          assert.ok('/key/default/index.html' in zk._client.client._hash);
+          assert.ok('/key/default/index.html' in hash);
         });
     });
 
     it('can get the keys of its children', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.hash = {
-        '/key/1/index.html': 1
+      var hash = {
+        '/key/1/index.html': 1,
+        '/key/1/index2.html': 1,
+        '/key/2/index3.html': 1,
+        '/key/1/index4.html': 1
       };
+
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
+
+      var promise = zk._client.getChildren('/key/1');
+      return assert.isFulfilled(promise)
+        .then(function(children) {
+          assert.deepEqual(children, {
+            children: [
+              'index.html',
+              'index2.html',
+              'index4.html'
+            ]
+          });
+        });
     });
 
     it('updates the list of recent uploads once upload is successful', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
+      var hash = {};
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.upload('key', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
-          assert.ok(zk._client.client._hash['/key/revisions/default']);
+          assert.ok(hash['/key/revisions/default']);
         });
     });
 
     it('trims the list of recent uploads and removes the index key', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key/1/index.html': '<html></html>',
         '/key/1/robots.txt': '',
         '/key/revisions/1': 1,
@@ -103,10 +135,16 @@ describe('zookeeper plugin', function() {
         '/key/revisions/10': 10
       };
 
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
+
       var promise = zk.upload('key', '11', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
-          var hash = zk._client.client._hash;
           assert.equal(Object.keys(hash).filter(function(key) {
             return key.indexOf('revisions') > -1;
           }).length, 10);
@@ -118,8 +156,7 @@ describe('zookeeper plugin', function() {
     });
 
     it('trims the list of recent uploads and leaves the active one', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key': '1',
         '/key/1/index.html': '<html></html>',
         '/key/1/robots.txt': '',
@@ -135,10 +172,16 @@ describe('zookeeper plugin', function() {
         '/key/revisions/10': 10
       };
 
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
+
       var promise = zk.upload('key', '11', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
-          var hash = zk._client.client._hash;
           assert.equal(hash['/key'], '1');
           assert.equal(Object.keys(hash).filter(function(key) {
             return key.indexOf('revisions') > -1;
@@ -152,24 +195,36 @@ describe('zookeeper plugin', function() {
 
     describe('generating the zookeeper path', function() {
       it('will use default as the revision if the revision/tag is not provided', function() {
-        var zk = new Zookeeper({}, FakeZookeeper);
+        var hash = {};
+        var zk = new Zookeeper({}, FakeZookeeper.extend({
+          init: function() {
+            this._super.apply(this, arguments);
+            this._hash = hash;
+          }
+        }));
 
         var promise = zk.upload('key', 'index.html', 'value');
         return assert.isFulfilled(promise)
           .then(function() {
-            assert.ok('/key/default/index.html' in zk._client.client._hash);
-            assert.ok('/key/revisions/default' in zk._client.client._hash);
+            assert.ok('/key/default/index.html' in hash);
+            assert.ok('/key/revisions/default' in hash);
           });
       });
 
       it('will use the provided revision', function() {
-        var zk = new Zookeeper({}, FakeZookeeper);
+        var hash = {};
+        var zk = new Zookeeper({}, FakeZookeeper.extend({
+          init: function() {
+            this._super.apply(this, arguments);
+            this._hash = hash;
+          }
+        }));
 
         var promise = zk.upload('key', 'everyonelovesdogs', 'index.html', 'value');
         return assert.isFulfilled(promise)
           .then(function() {
-            assert.ok('/key/everyonelovesdogs/index.html' in zk._client.client._hash);
-            assert.ok('/key/revisions/everyonelovesdogs' in zk._client.client._hash);
+            assert.ok('/key/everyonelovesdogs/index.html' in hash);
+            assert.ok('/key/revisions/everyonelovesdogs' in hash);
           });
       });
     });
@@ -177,26 +232,37 @@ describe('zookeeper plugin', function() {
 
   describe('#willDeploy', function() {
     it('creates the required missing paths before deploy', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
+      var hash = {};
+        var zk = new Zookeeper({}, FakeZookeeper.extend({
+          init: function() {
+            this._super.apply(this, arguments);
+            this._hash = hash;
+          }
+        }));
 
-      assert.ok(!('/key' in zk._client.client._hash));
-      assert.ok(!('/key/revisions' in zk._client.client._hash));
+      assert.ok(!('/key' in hash));
+      assert.ok(!('/key/revisions' in hash));
 
       var promise = zk.willDeploy('key');
       return assert.isFulfilled(promise)
         .then(function() {
-          assert.ok('/key' in zk._client.client._hash);
-          assert.ok('/key/revisions' in zk._client.client._hash);
+          assert.ok('/key' in hash);
+          assert.ok('/key/revisions' in hash);
         });
     });
   });
 
   describe('#willActivate', function() {
     it('sets the previous revision to the current revision', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key': '1'
       };
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.activeRevision('key');
       return assert.isFulfilled(promise)
@@ -208,13 +274,19 @@ describe('zookeeper plugin', function() {
 
   describe('#activate', function() {
     it('rejects if the revision does not exist in the list of uploaded revisions', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key': '1',
         '/key/revisions/1': 1,
         '/key/revisions/2': 2,
         '/key/revisions/3': 3
       };
+
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.activate('key', 'notme');
       return assert.isRejected(promise)
@@ -224,13 +296,19 @@ describe('zookeeper plugin', function() {
     });
 
     it('resolves and sets the current revision to the revision key provided', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key': '1',
         '/key/revisions/1': 1,
         '/key/revisions/2': 2,
         '/key/revisions/3': 3
       };
+
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.activate('key', '2');
       return assert.isFulfilled(promise)
@@ -242,12 +320,18 @@ describe('zookeeper plugin', function() {
 
   describe('#fetchRevisions', function() {
     it('lists the last existing revisions', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key/revisions/1': '1',
         '/key/revisions/2': '2',
         '/key/revisions/3': '3'
       };
+
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.fetchRevisions('key');
       return assert.isFulfilled(promise)
@@ -273,13 +357,19 @@ describe('zookeeper plugin', function() {
     });
 
     it('lists the last existing revisions and marks the active one', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
-      zk._client.client._hash = {
+      var hash = {
         '/key': '2',
         '/key/revisions/1': '1',
         '/key/revisions/2': '2',
         '/key/revisions/3': '3'
       };
+
+      var zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
 
       var promise = zk.fetchRevisions('key');
       return assert.isFulfilled(promise)

--- a/tests/unit/lib/zookeeper-promised-nodetest.js
+++ b/tests/unit/lib/zookeeper-promised-nodetest.js
@@ -1,0 +1,305 @@
+'use strict';
+var FakeZookeeper = require('../../helpers/fake-zk-client');
+var ZKError = require('../../../lib/zookeeper-error');
+var ZooKeeperPromised = require('../../../lib/zookeeper-promised');
+var assert  = require('ember-cli/tests/helpers/assert');
+
+describe('zookeeper promised', function() {
+  function makePromised(fakerOverrides, opts) {
+    return new ZooKeeperPromised(opts || {}, FakeZookeeper.extend(fakerOverrides || {}));
+  }
+
+  it('#init', function() {
+    var promised = makePromised({ _testProp: true }, { yay: 1234 });
+    assert.ok(promised);
+    assert.ok(promised.zkLib.prototype._testProp);
+    assert.deepEqual(promised.options, { yay: 1234 });
+  });
+
+  describe('#establishConnection/#connect/#close', function() {
+    it('establishes a connection property', function() {
+      var promised = makePromised();
+
+      assert.ok(!promised.connection);
+      promised.establishConnection();
+      return assert.isFulfilled(promised.connection);
+    });
+
+    it('only connects once if there is a successful connection', function() {
+      var instances = [];
+      var promised = makePromised({
+        init: function() {
+          this._super.apply(this, arguments);
+          instances.push(this);
+        }
+      });
+
+      return promised.connect().then(function() {
+        assert.equal(instances.length, 1);
+        return promised.connect();
+      }).then(function() {
+        assert.equal(instances.length, 1);
+      });
+    });
+
+    it('will create a new connection if the existing one fails/closes', function() {
+      var instances = [];
+      var closeCb;
+      var promised = makePromised({
+        init: function() {
+          this._super.apply(this, arguments);
+          instances.push(this);
+        },
+        on: function(type, cb) {
+          closeCb = cb;
+        }
+      });
+
+      return promised.connect().then(function() {
+        assert.equal(instances.length, 1);
+        closeCb(); // Send a close signal.
+        return promised.connect()
+      }).then(function() {
+        assert.equal(instances.length, 2);
+      });
+    });
+
+    it('will create a new connection if the existing one is manually closed', function() {
+      var instances = [];
+      var promised = makePromised({
+        init: function() {
+          this._super.apply(this, arguments);
+          instances.push(this);
+        }
+      });
+
+      return promised.connect().then(function() {
+        assert.equal(instances.length, 1);
+        return promised.close();
+      }).then(function() {
+        return promised.connect()
+      }).then(function() {
+        assert.equal(instances.length, 2);
+      });
+    });
+
+    it('will reject the connection if does not connect within connectionTimeout', function() {
+      var promised = makePromised({
+        connect: function() { /* Never connect. */ }
+      }, {
+        connectionTimeout: 1
+      });
+
+      return assert.isRejected(promised.connect(), /Timed out trying to connect to ZooKeeper/);
+    });
+
+    it('will reject the connection on an error', function() {
+      var promised = makePromised({
+        connect: function(cb) { cb('Connection error'); }
+      });
+
+      return assert.isRejected(promised.connect(), /Connection error/);
+    });
+
+    // This is the behavior now; but could change. Maybe a Number of retries policy? *shrug*
+    it('does not try to reconnect on a connection failure', function() {
+      var instances = [];
+      var promised = makePromised({
+        connect: function(cb) { cb('Connection error'); },
+        init: function() {
+          this._super.apply(this, arguments);
+          instances.push(this);
+        }
+      });
+
+      return promised.connect().catch(function(err) {
+        assert.equal(err, 'Connection error');
+        return promised.connect();
+      }).catch(function(err) {
+        assert.equal(err, 'Connection error');
+        assert.equal(instances.length, 1);
+      });
+    });
+  });
+
+  describe('#get', function() {
+    it('gets values', function() {
+      var promised = makePromised({
+        a_get: function(path, w, cb) {
+          cb(0, null, {}, 'howdy');
+        }
+      });
+
+      return assert.isFulfilled(promised.get('/test'))
+        .then(function(value) {
+          assert.equal(value.data, 'howdy');
+        });
+    });
+
+    it('rejects on errors', function() {
+      var promised = makePromised({
+        a_get: function(path, w, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.get('/test'), /System error/);
+    })
+  });
+
+  describe('#exists', function() {
+    it('has stat if exists', function() {
+      var promised = makePromised({
+        a_exists: function(path, w, cb) {
+          cb(0, null, {});
+        }
+      });
+
+      return assert.isFulfilled(promised.exists('/test'))
+        .then(function(res) {
+          assert.ok(res.stat);
+        });
+    });
+
+    it('has no stat if not exists', function() {
+      var promised = makePromised({
+        a_exists: function(path, w, cb) {
+          cb(0, null, null);
+        }
+      });
+
+      return assert.isFulfilled(promised.exists('/test'))
+        .then(function(res) {
+          assert.ok(!res.stat);
+        });
+    });
+
+    it('handles errors', function() {
+      var promised = makePromised({
+        a_exists: function(path, w, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.exists('/test'), /System error/);
+    });
+
+    it('handles ZNONODE error as falsey', function() {
+      var promised = makePromised({
+        a_exists: function(path, w, cb) {
+          cb(ZKError.ZNONODE);
+        }
+      });
+
+      return assert.isFulfilled(promised.exists('/test'))
+        .then(function(res) {
+          assert.ok(!res.stat);
+        });
+    });
+  });
+
+  describe('#set', function() {
+    it('sets values', function() {
+      var promised = makePromised({
+        a_set: function(p, d, v, cb) {
+          cb(0, null, {});
+        }
+      });
+
+      return assert.isFulfilled(promised.set('/test', '/hi'));
+    });
+
+    it('handles errors', function() {
+      var promised = makePromised({
+        a_set: function(p, d, v, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.set('/test'), /System error/);
+    });
+  });
+
+  describe('#create', function() {
+    it('creates values', function() {
+      var promised = makePromised({
+        a_create: function(p, d, v, cb) {
+          cb(0, null, p);
+        }
+      });
+
+      return assert.isFulfilled(promised.create('/test', '/hi'));
+    });
+
+    it('handles errors', function() {
+      var promised = makePromised({
+        a_create: function(p, d, v, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.create('/test'), /System error/);
+    });
+  });
+
+  describe('#delete', function() {
+    it('deletes values', function() {
+      var promised = makePromised({
+        a_delete_: function(p, d, cb) {
+          cb(0, null);
+        }
+      });
+
+      return assert.isFulfilled(promised.delete('/test', '/hi'));
+    });
+
+    it('handles errors', function() {
+      var promised = makePromised({
+        a_delete_: function(p, d, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.delete('/test'), /System error/);
+    });
+  });
+
+  describe('#getChildren', function() {
+    it('getChildrens values', function() {
+      var promised = makePromised({
+        a_get_children: function(p, d, cb) {
+          cb(0, null, ['1', '2', '3']);
+        }
+      });
+
+      return assert.isFulfilled(promised.getChildren('/test', '/hi'))
+        .then(function(res) {
+          assert.deepEqual(res, {
+            children: ['1', '2', '3']
+          });
+        });
+    });
+
+    it('handles errors', function() {
+      var promised = makePromised({
+        a_get_children: function(p, d, cb) {
+          cb(ZKError.ZSYSTEMERROR);
+        }
+      });
+
+      return assert.isRejected(promised.getChildren('/test'), /System error/);
+    });
+  });
+
+  describe('#_promisify', function() {
+    it('it will auto reject an action if returns error sync', function() {
+      var promised = makePromised({
+        a_get: function() {
+          return ZKError.ZSYSTEMERROR;
+        }
+      });
+
+      return assert.isRejected(promised.get('/hi'), /System error/);
+    });
+  });
+});

--- a/tests/unit/lib/zookeeper-proxy-nodetest.js
+++ b/tests/unit/lib/zookeeper-proxy-nodetest.js
@@ -17,7 +17,7 @@ var ClientStub = CoreObject.extend({
   a_create: function(p, d, f, cb) { cb(0, null, 'create'); }
 });
 
-describe('zookeeper proxy and zookeeper-promised', function() {
+describe('zookeeper proxy', function() {
   var proxy;
   beforeEach(function() {
     proxy = new ZookeeperProxy({}, ClientStub);

--- a/tests/unit/lib/zookeeper-proxy-nodetest.js
+++ b/tests/unit/lib/zookeeper-proxy-nodetest.js
@@ -152,27 +152,3 @@ describe('zookeeper proxy', function() {
     });
   });
 });
-
-describe('zookeeper proxy: connection errors', function() {
-  it('closes connections with error after specified timeout', function() {
-    var closeWasCalled = false;
-    var stub = ClientStub.extend({
-      connect: function() {
-        // A never resolving promise.
-        return new Promise(function() {});
-      },
-      close: function() {
-        closeWasCalled = true;
-        return Promise.resolve('close');
-      }
-    });
-    var proxy = new ZookeeperProxy({
-      connectionTimeout: 5
-    }, stub);
-
-    return proxy.connection.catch(function(err) {
-      assert.equal(err, 'Connection to Zookeeper timed out');
-      assert.ok(closeWasCalled);
-    });
-  });
-});


### PR DESCRIPTION
This update removes the `zk` library and replaces it with `zookeeper` (the standard node zookeeper library) as this will give us more control over how zookeeper connections are managed. We were getting some C memory allocation errors that appeared to be related to the `zk` library not properly listening for close events. (At least that's my best guess at this point). 
