### PR TITLE
Change Zookeeper Client Library

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,7 @@
   "noempty": false,
   "nonew": false,
   "nomen": false,
-  "onevar": false,
+  "onelet": false,
   "plusplus": false,
   "regexp": false,
   "undef": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+---
+language: node_js
+node_js:
+  - "6"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install
+
+script:
+  - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: "stable"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,9 +1,9 @@
 /*jshint node:true*/
 /* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+let EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 /* jshint node: true */
 'use strict';
-var DeployPluginBase = require('ember-cli-deploy-plugin');
-var path = require('path');
-var fs = require('fs');
-var Promise = require('ember-cli/lib/ext/promise');
-var denodeify = require('rsvp').denodeify;
-var readFile  = denodeify(fs.readFile);
+let DeployPluginBase = require('ember-cli-deploy-plugin');
+let path = require('path');
+let fs = require('fs');
+let Promise = require('ember-cli/lib/ext/promise');
+let denodeify = require('rsvp').denodeify;
+let readFile  = denodeify(fs.readFile);
 
 module.exports = {
   name: 'ember-cli-deploy-zookeeper',
   createDeployPlugin: function(options) {
-    var Zookeeper = require('./lib/zookeeper');
+    let Zookeeper = require('./lib/zookeeper');
 
-    var DeployPlugin = DeployPluginBase.extend({
+    let DeployPlugin = DeployPluginBase.extend({
       name: options.name,
 
       defaultConfig: {
@@ -26,8 +26,8 @@ module.exports = {
           return context.project.name();
         },
         didDeployMessage: function(context){
-          var revisionKey = context.revisionData && context.revisionData.revisionKey;
-          var activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
+          let revisionKey = context.revisionData && context.revisionData.revisionKey;
+          let activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
           if (revisionKey && !activatedRevisionKey) {
             return "Deployed but did not activate revision " + revisionKey + ". "
                  + "To activate, run: "
@@ -38,8 +38,8 @@ module.exports = {
           return context.commandOptions.revision || (context.revisionData && context.revisionData.revisionKey);
         },
         zookeeperDeployClient: function(context) {
-          var zkOptions = this;
-          var zkLib = context._zkLib;
+          let zkOptions = this;
+          let zkLib = context._zkLib;
           return new Zookeeper(zkOptions, zkLib);
         }
       },
@@ -47,20 +47,20 @@ module.exports = {
       requiredConfig: ['connect', 'files', 'distDir', 'keyPrefix', 'revisionKey', 'didDeployMessage', 'zookeeperDeployClient'],
 
       willDeploy: function(/* context */) {
-        var zkDeployClient = this.readConfig('zookeeperDeployClient');
-        var keyPrefix = this.readConfig('keyPrefix');
+        let zkDeployClient = this.readConfig('zookeeperDeployClient');
+        let keyPrefix = this.readConfig('keyPrefix');
         this.log('Validating presence of required paths for `' + keyPrefix + '`');
         return zkDeployClient.willDeploy(keyPrefix);
       },
 
       upload: function(/* context */) {
-        var zkDeployClient = this.readConfig('zookeeperDeployClient');
-        var revisionKey = this.readConfig('revisionKey');
-        var distDir = this.readConfig('distDir');
-        var files = this.readConfig('files');
-        var keyPrefix = this.readConfig('keyPrefix');
-        var self = this;
-        var paths = [];
+        let zkDeployClient = this.readConfig('zookeeperDeployClient');
+        let revisionKey = this.readConfig('revisionKey');
+        let distDir = this.readConfig('distDir');
+        let files = this.readConfig('files');
+        let keyPrefix = this.readConfig('keyPrefix');
+        let self = this;
+        let paths = [];
 
         return files.reduce(function(promise, fileName) {
             return promise
@@ -77,8 +77,8 @@ module.exports = {
       },
 
       willActivate: function() {
-        var zkDeployClient = this.readConfig('zookeeperDeployClient');
-        var keyPrefix = this.readConfig('keyPrefix');
+        let zkDeployClient = this.readConfig('zookeeperDeployClient');
+        let keyPrefix = this.readConfig('keyPrefix');
 
         return Promise.resolve(zkDeployClient.activeRevision(keyPrefix))
           .then(function(revisionKey) {
@@ -92,9 +92,9 @@ module.exports = {
       },
 
       activate: function() {
-        var zkDeployClient = this.readConfig('zookeeperDeployClient');
-        var revisionKey = this.readConfig('revisionKey');
-        var keyPrefix = this.readConfig('keyPrefix');
+        let zkDeployClient = this.readConfig('zookeeperDeployClient');
+        let revisionKey = this.readConfig('revisionKey');
+        let keyPrefix = this.readConfig('keyPrefix');
 
         this.log('Activating revision `' + revisionKey + '`', { verbose: true });
         return Promise.resolve(zkDeployClient.activate(keyPrefix, revisionKey))
@@ -110,15 +110,15 @@ module.exports = {
       },
 
       didDeploy: function(/* context */) {
-        var didDeployMessage = this.readConfig('didDeployMessage');
+        let didDeployMessage = this.readConfig('didDeployMessage');
         if (didDeployMessage) {
           this.log(didDeployMessage);
         }
       },
 
       fetchRevisions: function() {
-        var zkDeployClient = this.readConfig('zookeeperDeployClient');
-        var keyPrefix = this.readConfig('keyPrefix');
+        let zkDeployClient = this.readConfig('zookeeperDeployClient');
+        let keyPrefix = this.readConfig('keyPrefix');
 
         this.log('Listing revision for key: `' + keyPrefix + '`');
         return Promise.resolve(zkDeployClient.fetchRevisions(keyPrefix))
@@ -129,7 +129,7 @@ module.exports = {
       },
 
       _uploadFile: function(zkDeployClient, distDir, fileName, keyPrefix, revisionKey) {
-        var filePath = path.join(distDir, fileName);
+        let filePath = path.join(distDir, fileName);
         this.log(
           'Uploading `' + filePath + '` to `/' + keyPrefix + '/' + revisionKey + '/' + fileName + '`',
           { verbose: true }

--- a/lib/zookeeper-error.js
+++ b/lib/zookeeper-error.js
@@ -1,9 +1,9 @@
 // Borrowed from: https://github.com/oleksiyk/zk/blob/master/lib/error.js
 'use strict';
 
-var _ = require('lodash');
+let _ = require('lodash');
 
-var _messages = {
+let _messages = {
     '-1'   : 'System error',
     '-2'   : 'A runtime inconsistency was found',
     '-3'   : 'A data inconsistency was found',
@@ -32,7 +32,7 @@ var _messages = {
     '-122' : 'Attempt to create ephemeral node on a local session',
 };
 
-var ZkError = function (code, message, path) {
+let ZkError = function (code, message, path) {
     Error.call(this);
     Error.captureStackTrace(this, this.constructor); // capture the stack trace: http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
 

--- a/lib/zookeeper-promised.js
+++ b/lib/zookeeper-promised.js
@@ -1,53 +1,47 @@
-var CoreObject = require('core-object');
-var Promise = require('ember-cli/lib/ext/promise');
-var ZKError = require('./zookeeper-error');
+const CoreObject = require('core-object');
+const Promise = require('ember-cli/lib/ext/promise');
+const ZKError = require('./zookeeper-error');
+const Buffer = require('buffer').Buffer;
 
 module.exports = CoreObject.extend({
-  init: function(options, zkLib) {
+  init(options, zkLib) {
     this._super();
-    this.zkLib = zkLib || require('zookeeper')
+    this.zkLib = zkLib || require('node-zookeeper-client')
     this.options = options;
   },
 
-  establishConnection: function() {
-    var options = this.options;
-    var connectionTimeout = this.options.connectionTimeout || 10000;
+  establishConnection() {
+    let options = this.options;
+    let connectionTimeout = this.options.connectionTimeout || 10000;
 
-    var zk = new this.zkLib({
-      connect: options.connect,
+    let zk = this.zkLib.createClient(options.connect, {
       timeout: options.timeout,
       debug_level: this.zkLib,
       host_order_deterministic: true
     });
 
     this.connection = new Promise(function(resolve, reject) {
-      var timeout = setTimeout(function() {
+      let timeout = setTimeout(function() {
+        zk.close();
         reject('Timed out trying to connect to ZooKeeper');
       }, connectionTimeout);
 
-      zk.connect(function(err) {
-        // Clear the timeout.
+      zk.once('connected', () => {
         clearTimeout(timeout);
-
-        if (err) {
-          // there was an error connecting; reject.
-          reject(err);
-        } else {
-          // Othwerwise, success!
-          resolve(zk);
-        }
+        resolve(zk);
       });
+
+      zk.connect();
     });
 
     // Listen for close connection events.
-    var self = this;
-    zk.on('close', function() {
+    zk.once('disconnected', () => {
       // Remove the connection.
-      self.connection = null;
+      this.connection = null;
     });
   },
 
-  connect: function() {
+  connect() {
     if (!this.connection) {
       this.establishConnection();
     }
@@ -55,9 +49,8 @@ module.exports = CoreObject.extend({
     return this.connection;
   },
 
-  close: function() {
-    var self = this;
-    return this._promisify(function(zk, resolve) {
+  close() {
+    return this._promisify((zk, resolve) => {
       zk.close();
       resolve();
       this.connection = null;
@@ -65,27 +58,27 @@ module.exports = CoreObject.extend({
     });
   },
 
-  get: function(path) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_get(path, null, function(rc, error, stat, data) {
+  get(path) {
+    return this._promisify((zk, resolve, reject) => {
+      return zk.getData(path, (error, data, stat) => {
         // If there is an error of some sort.
-        if (rc !== 0) {
-          return reject(new ZKError(rc, error, path));
+        if (error) {
+          return reject(error);
         }
 
         return resolve({
           stat: stat,
-          data: data
+          data: data && data.toString('utf8')
         });
       });
     });
   },
 
-  exists: function(path) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_exists(path, null, function(rc, error, stat) {
-        if (rc !== 0 && rc !== ZKError.ZNONODE) {
-          return reject(new ZKError(rc, error, path));
+  exists(path) {
+    return this._promisify((zk, resolve, reject) => {
+      return zk.exists(path, (error, stat) => {
+        if (error) {
+          return reject(error);
         }
 
         return resolve({
@@ -95,11 +88,12 @@ module.exports = CoreObject.extend({
     });
   },
 
-  set: function(path, data) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_set(path, data, -1, function(rc, error, stat) {
-        if (rc !== 0) {
-          return reject(new ZKError(rc, error, path));
+  set(path, data = '') {
+    return this._promisify((zk, resolve, reject) => {
+      const dataBuffer = Buffer.from(data.toString(), 'utf8');
+      return zk.setData(path, dataBuffer, (error, stat) => {
+        if (error) {
+          return reject(error);
         }
 
         resolve({
@@ -109,23 +103,32 @@ module.exports = CoreObject.extend({
     });
   },
 
-  create: function(path, data, flags) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_create(path, data, flags, function(rc, error, _path) {
-        if (rc !== 0) {
-          return reject(new ZKError(rc, error, path));
+  create(path, data) {
+    return this._promisify((zk, resolve, reject) => {
+      const args = [path];
+
+      // Only include the data argument if there is data passed
+      if (data) {
+        args.push(Buffer.from(data, 'utf8'));
+      }
+
+      args.push((error, resolvedPath) => {
+        if (error) {
+          return reject(error);
         }
 
-        resolve(_path);
+        resolve(resolvedPath);
       });
+
+      return zk.create(...args);
     });
   },
 
-  delete: function(path) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_delete_(path, -1, function(rc, error) {
-        if (rc !== 0) {
-          return reject(new ZKError(rc, error, path));
+  delete(path) {
+    return this._promisify((zk, resolve, reject) => {
+      return zk.remove(path, -1, (error) => {
+        if (error) {
+          return reject(error);
         }
 
         resolve();
@@ -133,11 +136,11 @@ module.exports = CoreObject.extend({
     });
   },
 
-  getChildren: function(path) {
-    return this._promisify(function(zk, resolve, reject) {
-      return zk.a_get_children(path, null, function(rc, error, children) {
-        if (rc !== 0) {
-          return reject(new ZKError(rc, error, path));
+  getChildren(path) {
+    return this._promisify((zk, resolve, reject) => {
+      return zk.getChildren(path, (error, children, stats) => {
+        if (error) {
+          return reject(error);
         }
 
         resolve({
@@ -147,16 +150,10 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _promisify: function(cb) {
-    var self = this;
-    return this.connect().then(function(zk) {
-      return new Promise(function(resolve, reject) {
-        var ret = cb.call(self, zk, resolve, reject);
-
-        // If it immediately returned with an error, reject.
-        if (ret !== ZKError.ZOK) {
-          reject(new ZKError(ret));
-        }
+  _promisify(cb) {
+    return this.connect().then((zk) => {
+      return new Promise((resolve, reject) => {
+        cb(zk, resolve, reject);
       });
     });
   }

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -1,9 +1,9 @@
-var CoreObject = require('core-object');
-var Promise = require('ember-cli/lib/ext/promise');
-var ZKPromised = require('./zookeeper-promised');
+let CoreObject = require('core-object');
+let Promise = require('ember-cli/lib/ext/promise');
+let ZKPromised = require('./zookeeper-promised');
 
 module.exports = CoreObject.extend({
-  init: function(options, zkLib) {
+  init(options, zkLib) {
     this._super();
     this.client = new ZKPromised(options, zkLib);
     this._createPromisesHash = {};
@@ -14,8 +14,8 @@ module.exports = CoreObject.extend({
   delete: proxyMethod('delete'),
   create: proxyMethod('create'),
 
-  createIfNotExists: function(key) {
-    var client = this.client;
+  createIfNotExists(key) {
+    let client = this.client;
     return this._createIfNotExist(key)
       .catch(function(err) {
         client.close();
@@ -23,9 +23,9 @@ module.exports = CoreObject.extend({
       });
   },
 
-  set: function(key, value) {
-    var client = this.client;
-    var arity = arguments.length;
+  set(key, value) {
+    let client = this.client;
+    let arity = arguments.length;
 
     return this.connect()
       .then(this._createIfNotExist.bind(this, key))
@@ -38,9 +38,9 @@ module.exports = CoreObject.extend({
       });
   },
 
-  _createIfNotExist: function(key) {
-    var client = this.client;
-    var _createPromisesHash = this._createPromisesHash;
+  _createIfNotExist(key) {
+    let client = this.client;
+    let _createPromisesHash = this._createPromisesHash;
 
     return this.connect()
       .then(client.exists.bind(client, key))
@@ -59,23 +59,18 @@ module.exports = CoreObject.extend({
       });
   },
 
-  connect: function() {
+  connect() {
     return this.client.connect();
   }
 });
 
-function proxyMethod(/* methodName, ...additionalArgs */) {
-  var outerArgs = Array.prototype.slice.apply(arguments);
-  var methodName = outerArgs.shift();
-
-  return function() {
-    var args = Array.prototype.slice.apply(arguments);
-    var allArgs = args.concat(outerArgs);
-    var client = this.client;
+function proxyMethod(methodName, ...outerArgs) {
+  return function(...innerArgs) {
+    let client = this.client;
 
     return this.connect()
       .then(function() {
-        return client[methodName].apply(client, allArgs);
+        return client[methodName].apply(client, innerArgs.concat(outerArgs));
       })
       .catch(function(err) {
         client.close();

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -1,11 +1,11 @@
-var CoreObject = require('core-object');
-var path = require('path');
-var Promise = require('ember-cli/lib/ext/promise');
-var zkProxy = require('./zookeeper-proxy');
-var REVISION_PATH = 'revisions';
+let CoreObject = require('core-object');
+let path = require('path');
+let Promise = require('ember-cli/lib/ext/promise');
+let zkProxy = require('./zookeeper-proxy');
+let REVISION_PATH = 'revisions';
 
 module.exports = CoreObject.extend({
-  init: function(options, lib) {
+  init(options, lib) {
     this._super();
     this.options = options;
     
@@ -18,18 +18,20 @@ module.exports = CoreObject.extend({
     this._maxNumberOfRecentUploads = 10;
     this._allowOverwrite = !!options.allowOverwrite;
   },
-  willDeploy: function(keyPrefix) {
+  willDeploy(keyPrefix) {
     // Make sure that the /keyPrefix/revision path exists
-    return this._createMissingParentPaths([keyPrefix, REVISION_PATH]);
+    const paths = keyPrefix.replace(/^\//, '').split('/');
+    paths.push(REVISION_PATH);
+    return this._createMissingParentPaths(paths);
   },
-  upload: function(/*keyPrefix, revisionKey, fileName, value*/) {
+  upload(/*keyPrefix, revisionKey, fileName, value*/) {
     // Upload the file to the specified key, given the revision number
-    var args = Array.prototype.slice.call(arguments);
-    var keyPrefix = args.shift();
-    var value = args.pop();
-    var fileName = args.pop();
-    var revisionKey = args[0] || 'default';
-    var zkKey = makePath(keyPrefix, revisionKey, fileName);
+    let args = Array.prototype.slice.call(arguments);
+    let keyPrefix = args.shift();
+    let value = args.pop();
+    let fileName = args.pop();
+    let revisionKey = args[0] || 'default';
+    let zkKey = makePath(keyPrefix, revisionKey, fileName);
 
     return Promise.resolve()
       .then(this._createMissingParentPaths.bind(this, [keyPrefix, revisionKey]))
@@ -39,23 +41,22 @@ module.exports = CoreObject.extend({
         return zkKey;
       });
   },
-  trimRecentUploads: function(keyPrefix, revisionKey) {
-    var maxEntries = this._maxNumberOfRecentUploads;
-    var revisionKey = revisionKey || 'default';
+  trimRecentUploads(keyPrefix, revisionKey = 'default') {
+    let maxEntries = this._maxNumberOfRecentUploads;
     return Promise.resolve()
       .then(this._updateRecentUploadsList.bind(this, keyPrefix, revisionKey))
       .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries));
   },
-  activate: function(keyPrefix, revisionKey) {
+  activate(keyPrefix, revisionKey) {
     return Promise.resolve()
       .then(this._listRevisions.bind(this, keyPrefix))
       .then(this._validateRevisionKey.bind(this, revisionKey))
       .then(this._activateRevisionKey.bind(this, keyPrefix, revisionKey))
       .then(this.activeRevision.bind(this, keyPrefix));
   },
-  activeRevision: function(keyPrefix) {
-    var path = makePath(keyPrefix);
-    var client = this._client;
+  activeRevision(keyPrefix) {
+    let path = makePath(keyPrefix);
+    let client = this._client;
     return Promise.resolve()
       .then(function() {
         return client.get(path);
@@ -65,13 +66,13 @@ module.exports = CoreObject.extend({
       });
   },
 
-  fetchRevisions: function(keyPrefix) {
+  fetchRevisions(keyPrefix) {
     return this._fetchRevisions(keyPrefix);
   },
 
-  _fetchRevisions: function(keyPrefix) {
-    var self = this;
-    var client = this._client;
+  _fetchRevisions(keyPrefix) {
+    let self = this;
+    let client = this._client;
 
     return Promise.resolve()
       .then(function() {
@@ -81,7 +82,7 @@ module.exports = CoreObject.extend({
         });
       })
       .then(function(results) {
-        var current = results.current;
+        let current = results.current;
         return results.revisions.map(function(revision) {
           revision.active = current ? revision.revision === current : false;
           return revision;
@@ -89,9 +90,9 @@ module.exports = CoreObject.extend({
       });
   },
 
-  _listRevisions: function(keyPrefix) {
-    var path = makePath(keyPrefix, REVISION_PATH);
-    var self = this;
+  _listRevisions(keyPrefix) {
+    let path = makePath(keyPrefix, REVISION_PATH);
+    let self = this;
     return Promise.resolve()
       .then(this._client.getChildren.bind(this._client, path))
       .then(function(res) {
@@ -100,8 +101,8 @@ module.exports = CoreObject.extend({
         }));
       });
   },
-  _getRevisionData: function(keyPrefix, revision) {
-    var path = makePath(keyPrefix, REVISION_PATH, revision);
+  _getRevisionData(keyPrefix, revision) {
+    let path = makePath(keyPrefix, REVISION_PATH, revision);
     return Promise.resolve()
       .then(this._client.get.bind(this._client, path))
       .then(function(res) {
@@ -111,25 +112,23 @@ module.exports = CoreObject.extend({
         };
       });
   },
-  _createMissingParentPaths: function(parts) {
-    var client = this._client;
-    var self = this;
+  _createMissingParentPaths(parts) {
+    const client = this._client;
 
     // Make sure this operation is done serially.
-    return parts.reduce(function(promise, key, index) {
-      var key = makePath.apply(null, parts.slice(0, index + 1));
+    return parts.reduce(function(promise, _, index) {
+      const key = makePath.apply(null, parts.slice(0, index + 1));
+
       return promise.then(function() {
         return client.createIfNotExists(key);
       });
-    }, Promise.resolve()).then(function(res) {
-      return res;
-    });
+    }, Promise.resolve()).then((res) => res);
   },
 
-  _rejectIfKeyExists: function(zkKey) {
-    var self = this;
-    var allowOverwrite = !!this._allowOverwrite;
-    var promise = Promise.resolve();
+  _rejectIfKeyExists(zkKey) {
+    let self = this;
+    let allowOverwrite = !!this._allowOverwrite;
+    let promise = Promise.resolve();
 
     if (!allowOverwrite) {
       return promise.then(function() {
@@ -142,28 +141,28 @@ module.exports = CoreObject.extend({
     return promise;
   },
 
-  _exists: function(zkKey) {
+  _exists(zkKey) {
     return this._client.exists(zkKey).then(function(res) {
       // Stat is undefined if the key does not exist.
       return !!res.stat;
     });
   },
 
-  _upload: function(zkKey, value) {
-    var client = this._client;
+  _upload(zkKey, value) {
+    let client = this._client;
     return client.set(zkKey, value);
   },
 
-  _updateRecentUploadsList: function(keyPrefix, revisionKey) {
-    var client = this._client;
-    var timeAdded = new Date().getTime();
-    var listKey = makePath(keyPrefix, REVISION_PATH, revisionKey);
+  _updateRecentUploadsList(keyPrefix, revisionKey) {
+    let client = this._client;
+    let timeAdded = new Date().getTime();
+    let listKey = makePath(keyPrefix, REVISION_PATH, revisionKey);
     return client.set(listKey, timeAdded);
   },
 
-  _deleteChildrenAndSelf: function(path) {
+  _deleteChildrenAndSelf(path) {
     // Delete the children of this path and itself.
-    var client = this._client;
+    let client = this._client;
     return client.getChildren(path).then(function(res) {
       return Promise.all(res.children.map(function(child) {
         return client.delete(makePath(path, child));
@@ -173,16 +172,16 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _trimRecentUploadsList: function(keyPrefix, maxEntries) {
-    var client = this._client;
-    var self = this;
+  _trimRecentUploadsList(keyPrefix, maxEntries) {
+    let client = this._client;
+    let self = this;
 
     return this._fetchRevisions(keyPrefix).then(function(results) {
       // Get all the revisions.
       return Promise.all(results.filter(function(revision) {
         return !revision.active;
       }).map(function(revision) {
-        var path = makePath(keyPrefix, REVISION_PATH, revision.revision);
+        let path = makePath(keyPrefix, REVISION_PATH, revision.revision);
         return Promise.hash({
           clientData: client.get(path),
           revision: revision,
@@ -194,12 +193,12 @@ module.exports = CoreObject.extend({
       revisionsData.sort(function(a, b) {
         return a.clientData.data > b.clientData.data ? -1 : 1;
       });
-
+      
       // Get the oldest items beyond the maximum number of entries.
-      var revisionsToRemove = revisionsData.slice(maxEntries);
+      let revisionsToRemove = revisionsData.slice(maxEntries);
 
       return Promise.all(revisionsToRemove.map(function(revisionData) {
-        var revision = revisionData.revision.revision;
+        let revision = revisionData.revision.revision;
         return Promise.all([
           client.delete(revisionData.path),
           self._deleteChildrenAndSelf(makePath(keyPrefix, revision))
@@ -207,20 +206,19 @@ module.exports = CoreObject.extend({
       }));
     });
   },
-  _validateRevisionKey: function(revisionKey, revisions) {
-    var revisionsList = revisions.map(function(revision) {
+  _validateRevisionKey(revisionKey, revisions) {
+    let revisionsList = revisions.map(function(revision) {
       return revision.revision;
     });
     return revisionsList.indexOf(revisionKey) > -1 ? Promise.resolve() : Promise.reject('`' + revisionKey + '` is not a valid revision key');
   },
-  _activateRevisionKey: function(keyPrefix, revision) {
-    var path = makePath(keyPrefix);
+  _activateRevisionKey(keyPrefix, revision) {
+    let path = makePath(keyPrefix);
     return this._client.set(path, revision);
   }
 });
 
-function makePath(/* args */) {
-  var args = Array.prototype.slice.call(arguments);
+function makePath(...args) {
   args.unshift('/');
-  return path.join.apply(path, args);
+  return path.join(...args);
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.9",
     "lodash": "^4.6.1",
-    "rsvp": "^3.2.1",
-    "zookeeper": "3.4.9-3"
+    "node-zookeeper-client": "^0.2.2",
+    "rsvp": "^3.2.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
     environment: environment,
     baseURL: '/',

--- a/tests/helpers/assert.js
+++ b/tests/helpers/assert.js
@@ -1,5 +1,5 @@
-var chai = require('chai');
-var chaiAsPromised = require("chai-as-promised");
+let chai = require('chai');
+let chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 
 module.exports = chai.assert;

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var glob = require('glob');
-var Mocha = require('mocha');
+let glob = require('glob');
+let Mocha = require('mocha');
 
-var mocha = new Mocha({
+let mocha = new Mocha({
   reporter: 'spec'
 });
 
-var arg = process.argv[2];
-var root = 'tests/';
+let arg = process.argv[2];
+let root = 'tests/';
 
 function addFiles(mocha, files) {
   glob.sync(root + files).forEach(mocha.addFile.bind(mocha));

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var Promise = require('ember-cli/lib/ext/promise');
-var assert  = require('../helpers/assert');
-var FakeZookeeper = require('../helpers/fake-zk-client');
+let Promise = require('ember-cli/lib/ext/promise');
+let assert  = require('../helpers/assert');
+let FakeZookeeper = require('../helpers/fake-zk-client');
 
-var stubProject = {
+let stubProject = {
   name: function() {
     return 'my-project';
   }
 };
 
 describe('ember-cli-deploy-zookeeper', function() {
-  var subject, mockUi;
+  let subject, mockUi;
 
   beforeEach(function() {
     subject = require('../../index');
@@ -26,7 +26,7 @@ describe('ember-cli-deploy-zookeeper', function() {
   });
 
   it('has a name', function() {
-    var result = subject.createDeployPlugin({
+    let result = subject.createDeployPlugin({
       name: 'test-plugin'
     });
 
@@ -34,7 +34,7 @@ describe('ember-cli-deploy-zookeeper', function() {
   });
 
   it('implements the correct hooks', function() {
-    var plugin = subject.createDeployPlugin({
+    let plugin = subject.createDeployPlugin({
       name: 'test-plugin'
     });
     assert.ok(plugin.configure);
@@ -45,11 +45,11 @@ describe('ember-cli-deploy-zookeeper', function() {
 
   describe('configure hook', function() {
     it('runs without error if config is ok', function() {
-      var plugin = subject.createDeployPlugin({
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
 
-      var context = {
+      let context = {
         ui: mockUi,
         project: stubProject,
         config: {
@@ -66,11 +66,11 @@ describe('ember-cli-deploy-zookeeper', function() {
     });
 
     it('passes through config options', function() {
-      var plugin = subject.createDeployPlugin({
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
 
-      var context = {
+      let context = {
         ui: mockUi,
         project: stubProject,
         config: {
@@ -84,18 +84,18 @@ describe('ember-cli-deploy-zookeeper', function() {
 
       plugin.beforeHook(context);
       plugin.configure(context);
-      var zkClient = plugin.readConfig('zookeeperDeployClient');
+      let zkClient = plugin.readConfig('zookeeperDeployClient');
       assert.equal(zkClient.options.host, 'somehost');
       assert.equal(zkClient.options.port, 1234);
     });
 
     describe('resolving revisionKey from the pipeline', function() {
       it('uses the config data if it already exists', function() {
-        var plugin = subject.createDeployPlugin({
+        let plugin = subject.createDeployPlugin({
           name: 'zookeeper'
         });
 
-        var context = {
+        let context = {
           ui: mockUi,
           project: stubProject,
           config: {
@@ -116,16 +116,16 @@ describe('ember-cli-deploy-zookeeper', function() {
       });
 
       it('uses the commandOptions value if it exists', function() {
-        var plugin = subject.createDeployPlugin({
+        let plugin = subject.createDeployPlugin({
           name: 'zookeeper'
         });
 
-        var config = {
+        let config = {
           host: 'somehost',
           port: 1234
         };
 
-        var context = {
+        let context = {
           ui: mockUi,
           project: stubProject,
           config: {
@@ -146,16 +146,16 @@ describe('ember-cli-deploy-zookeeper', function() {
       });
 
       it('uses the context value if it exists and commandOptions doesn\'t', function() {
-        var plugin = subject.createDeployPlugin({
+        let plugin = subject.createDeployPlugin({
           name: 'zookeeper'
         });
 
-        var config = {
+        let config = {
           host: 'somehost',
           port: 1234
         };
 
-        var context = {
+        let context = {
           ui: mockUi,
           project: stubProject,
           config: {
@@ -175,7 +175,7 @@ describe('ember-cli-deploy-zookeeper', function() {
     });
 
     describe('without providing config', function () {
-      var config, plugin, context;
+      let config, plugin, context;
       beforeEach(function() {
         config = { };
         plugin = subject.createDeployPlugin({
@@ -191,7 +191,7 @@ describe('ember-cli-deploy-zookeeper', function() {
 
       it('warns about missing optional config', function() {
         plugin.configure(context);
-        var messages = mockUi.messages.reduce(function(previous, current) {
+        let messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
             previous.push(current);
           }
@@ -212,7 +212,7 @@ describe('ember-cli-deploy-zookeeper', function() {
     });
 
     describe('with a keyPrefix provided', function () {
-      var config, plugin, context;
+      let config, plugin, context;
       beforeEach(function() {
         config = {
           zookeeper: {
@@ -231,7 +231,7 @@ describe('ember-cli-deploy-zookeeper', function() {
       });
       it('warns about missing optional files, distDir, activationSuffix, revisionKey, didDeployMessage, and connection info', function() {
         plugin.configure(context);
-        var messages = mockUi.messages.reduce(function(previous, current) {
+        let messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
             previous.push(current);
           }
@@ -251,8 +251,8 @@ describe('ember-cli-deploy-zookeeper', function() {
   });
 
   describe('upload hook', function() {
-    var plugin;
-    var context;
+    let plugin;
+    let context;
 
     it('uploads the index', function() {
       plugin = subject.createDeployPlugin({
@@ -317,15 +317,15 @@ describe('ember-cli-deploy-zookeeper', function() {
 
   describe('activate hook', function() {
     it('activates revision', function() {
-      var activateCalled = false;
-      var activatePath = '';
-      var activateRevision = '';
+      let activateCalled = false;
+      let activatePath = '';
+      let activateRevision = '';
 
-      var plugin = subject.createDeployPlugin({
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
 
-      var context = {
+      let context = {
         ui: mockUi,
         project: stubProject,
         config: {
@@ -360,11 +360,11 @@ describe('ember-cli-deploy-zookeeper', function() {
     });
 
     it('rejects if an error is thrown when activating', function() {
-      var plugin = subject.createDeployPlugin({
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
 
-      var context = {
+      let context = {
         ui: mockUi,
         project: stubProject,
         config: {
@@ -394,8 +394,8 @@ describe('ember-cli-deploy-zookeeper', function() {
 
   describe('willActivate hook', function() {
     it('returns the current active version', function() {
-      var plugin;
-      var context;
+      let plugin;
+      let context;
 
       plugin = subject.createDeployPlugin({
         name: 'zookeeper'
@@ -437,12 +437,12 @@ describe('ember-cli-deploy-zookeeper', function() {
 
   describe('willDeploy hook', function() {
     it('prints a message for the validation of required zookeeper paths', function() {
-      var messageOutput = '';
-      var plugin = subject.createDeployPlugin({
+      let messageOutput = '';
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
 
-      var context = {
+      let context = {
         deployTarget: 'qa',
         ui: {
           write: function(message) {
@@ -470,15 +470,15 @@ describe('ember-cli-deploy-zookeeper', function() {
 
   describe('didDeploy hook', function() {
     it('prints default message about lack of activation when revision has not been activated', function() {
-      var messageOutput = '';
+      let messageOutput = '';
 
-      var plugin = subject.createDeployPlugin({
+      let plugin = subject.createDeployPlugin({
         name: 'zookeeper'
       });
       plugin.upload = function(){};
       plugin.activate = function(){};
 
-      var context = {
+      let context = {
         deployTarget: 'qa',
         ui: {
           write: function(message){
@@ -507,9 +507,9 @@ describe('ember-cli-deploy-zookeeper', function() {
   });
 
   describe('fetchRevisions hook', function() {
-    it('fills the revisions variable on context', function() {
-      var plugin;
-      var context;
+    it('fills the revisions letiable on context', function() {
+      let plugin;
+      let context;
 
       plugin = subject.createDeployPlugin({
         name: 'zookeeper'
@@ -553,7 +553,7 @@ describe('ember-cli-deploy-zookeeper', function() {
   });
 
   it('reads file contents properly', function() {
-    var result = subject.createDeployPlugin({
+    let result = subject.createDeployPlugin({
       name: 'test-plugin'
     });
 

--- a/tests/unit/lib/zookeeper-nodetest.js
+++ b/tests/unit/lib/zookeeper-nodetest.js
@@ -1,11 +1,11 @@
 'use strict';
-var FakeZookeeper = require('../../helpers/fake-zk-client');
-var ZKError = require('../../../lib/zookeeper-error');
-var Promise = require('ember-cli/lib/ext/promise');
-var assert  = require('../../helpers/assert');
+let FakeZookeeper = require('../../helpers/fake-zk-client');
+let ZKError = require('../../../lib/zookeeper-error');
+let Promise = require('ember-cli/lib/ext/promise');
+let assert  = require('../../helpers/assert');
 
 describe('zookeeper plugin', function() {
-  var Zookeeper;
+  let Zookeeper;
 
   beforeEach(function() {
     Zookeeper = require('../../../lib/zookeeper');
@@ -13,27 +13,27 @@ describe('zookeeper plugin', function() {
 
   describe('#upload', function() {
     it('rejects if the key already exists in zookeeper', function() {
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
-        a_exists: function(path, watch, cb) {
-          cb(ZKError.ZNODEEXISTS, 'Value already exists for key: ' + path);
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
+        exists(path, cb) {
+          cb('Value already exists for key: ' + path);
           return 0;
         }
       }));
 
-      var promise = zk.upload('key', 'index.html', 'value');
-      return assert.isRejected(promise, /^The node already exists/);
+      let promise = zk.upload('key', 'index.html', 'value');
+      return assert.isRejected(promise, /^Value already exists for ke/);
     });
 
     it('uploads the contents if the key does not already exist', function() {
-      var hash;
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let hash;
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           hash = this._hash;
         }
       }));
 
-      var promise = zk.upload('key', 'index.html', 'value');
+      let promise = zk.upload('key', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok('/key/default/index.html' in hash);
@@ -41,9 +41,9 @@ describe('zookeeper plugin', function() {
     });
 
     it('does not support creating a node if it already exists', function() {
-      var zk = new Zookeeper({}, FakeZookeeper);
+      let zk = new Zookeeper({}, FakeZookeeper);
       zk.testCreatingNodeTwice = function(key) {
-        var client = this._client;
+        let client = this._client;
         return client.create(key, '').then(function() {
           return client.create(key, '');
         });
@@ -51,15 +51,15 @@ describe('zookeeper plugin', function() {
 
       return assert.isRejected(zk.testCreatingNodeTwice('/key'))
         .then(function(err) {
-          assert.equal(err.message, 'The node already exists');
+          assert.equal(err.toString(), 'The node already exists');
         });
     });
 
     it('uploads the contents if the key already exists but allowOverwrite is true', function() {
-      var fileUploaded = false;
-      var nodeCreated = false;
-      var hash;
-      var zk = new Zookeeper({
+      let fileUploaded = false;
+      let nodeCreated = false;
+      let hash;
+      let zk = new Zookeeper({
         allowOverwrite: true
       }, FakeZookeeper.extend({
         init: function() {
@@ -68,7 +68,7 @@ describe('zookeeper plugin', function() {
         }
       }));
 
-      var promise = zk.upload('key', 'index.html', 'value');
+      let promise = zk.upload('key', 'index.html', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok('/key/default/index.html' in hash);
@@ -76,21 +76,21 @@ describe('zookeeper plugin', function() {
     });
 
     it('can get the keys of its children', function() {
-      var hash = {
+      let hash = {
         '/key/1/index.html': 1,
         '/key/1/index2.html': 1,
         '/key/2/index3.html': 1,
         '/key/1/index4.html': 1
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk._client.getChildren('/key/1');
+      let promise = zk._client.getChildren('/key/1');
       return assert.isFulfilled(promise)
         .then(function(children) {
           assert.deepEqual(children, {
@@ -104,15 +104,15 @@ describe('zookeeper plugin', function() {
     });
 
     it('updates the list of recent uploads once upload is successful', function() {
-      var hash = {};
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let hash = {};
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.upload('key', 'index.html', 'value').then(function() {
+      let promise = zk.upload('key', 'index.html', 'value').then(function() {
         return zk.trimRecentUploads('key');
       });
       return assert.isFulfilled(promise)
@@ -122,7 +122,7 @@ describe('zookeeper plugin', function() {
     });
 
     it('trims the list of recent uploads and removes the index key', function() {
-      var hash = {
+      let hash = {
         '/key/1/index.html': '<html></html>',
         '/key/1/robots.txt': '',
         '/key/revisions/1': 1,
@@ -137,16 +137,17 @@ describe('zookeeper plugin', function() {
         '/key/revisions/10': 10
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
-        init: function() {
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
+        init() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.upload('key', '11', 'index.html', 'value').then(function() {
+      let promise = zk.upload('key', '11', 'index.html', 'value').then(function() {
         return zk.trimRecentUploads('key', '11');
       });
+
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(Object.keys(hash).filter(function(key) {
@@ -160,7 +161,7 @@ describe('zookeeper plugin', function() {
     });
 
     it('trims the list of recent uploads and leaves the active one', function() {
-      var hash = {
+      let hash = {
         '/key': '1',
         '/key/1/index.html': '<html></html>',
         '/key/1/robots.txt': '',
@@ -176,14 +177,14 @@ describe('zookeeper plugin', function() {
         '/key/revisions/10': 10
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.upload('key', '11', 'index.html', 'value').then(function() {
+      let promise = zk.upload('key', '11', 'index.html', 'value').then(function() {
         return zk.trimRecentUploads('key', '11');
       });
       return assert.isFulfilled(promise)
@@ -201,17 +202,18 @@ describe('zookeeper plugin', function() {
 
     describe('generating the zookeeper path', function() {
       it('will use default as the revision if the revision/tag is not provided', function() {
-        var hash = {};
-        var zk = new Zookeeper({}, FakeZookeeper.extend({
-          init: function() {
+        const hash = {};
+        const zk = new Zookeeper({}, FakeZookeeper.extend({
+          init() {
             this._super.apply(this, arguments);
             this._hash = hash;
           }
         }));
 
-        var promise = zk.upload('key', 'index.html', 'value').then(function() {
+        const promise = zk.upload('key', 'index.html', 'value').then(function() {
           return zk.trimRecentUploads('key');
         });
+
         return assert.isFulfilled(promise)
           .then(function() {
             assert.ok('/key/default/index.html' in hash);
@@ -220,15 +222,15 @@ describe('zookeeper plugin', function() {
       });
 
       it('will use the provided revision', function() {
-        var hash = {};
-        var zk = new Zookeeper({}, FakeZookeeper.extend({
+        let hash = {};
+        let zk = new Zookeeper({}, FakeZookeeper.extend({
           init: function() {
             this._super.apply(this, arguments);
             this._hash = hash;
           }
         }));
 
-        var promise = zk.upload('key', 'everyonelovesdogs', 'index.html', 'value').then(function() {
+        let promise = zk.upload('key', 'everyonelovesdogs', 'index.html', 'value').then(function() {
           return zk.trimRecentUploads('key', 'everyonelovesdogs');
         });
         return assert.isFulfilled(promise)
@@ -242,8 +244,8 @@ describe('zookeeper plugin', function() {
 
   describe('#willDeploy', function() {
     it('creates the required missing paths before deploy', function() {
-      var hash = {};
-        var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let hash = {};
+        let zk = new Zookeeper({}, FakeZookeeper.extend({
           init: function() {
             this._super.apply(this, arguments);
             this._hash = hash;
@@ -253,28 +255,50 @@ describe('zookeeper plugin', function() {
       assert.ok(!('/key' in hash));
       assert.ok(!('/key/revisions' in hash));
 
-      var promise = zk.willDeploy('key');
+      let promise = zk.willDeploy('key');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok('/key' in hash);
           assert.ok('/key/revisions' in hash);
         });
     });
-  });
 
-  describe('#willActivate', function() {
-    it('sets the previous revision to the current revision', function() {
-      var hash = {
-        '/key': '1'
-      };
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+    it('creates the required missing nested paths before deploy', function() {
+      let hash = {};
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.activeRevision('key');
+      assert.ok(!('/nested' in hash));
+      assert.ok(!('/nested/key' in hash));
+      assert.ok(!('/nested/key/revisions' in hash));
+
+      let promise = zk.willDeploy('/nested/key');
+      return assert.isFulfilled(promise)
+        .then(function() {
+          assert.ok('/nested' in hash);
+          assert.ok('/nested/key' in hash);
+          assert.ok('/nested/key/revisions' in hash);
+        });
+    });
+  });
+
+  describe('#willActivate', function() {
+    it('sets the previous revision to the current revision', function() {
+      let hash = {
+        '/key': '1'
+      };
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
+        init: function() {
+          this._super.apply(this, arguments);
+          this._hash = hash;
+        }
+      }));
+
+      let promise = zk.activeRevision('key');
       return assert.isFulfilled(promise)
         .then(function(revision) {
           assert.equal(revision, '1');
@@ -284,21 +308,21 @@ describe('zookeeper plugin', function() {
 
   describe('#activate', function() {
     it('rejects if the revision does not exist in the list of uploaded revisions', function() {
-      var hash = {
+      let hash = {
         '/key': '1',
         '/key/revisions/1': 1,
         '/key/revisions/2': 2,
         '/key/revisions/3': 3
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.activate('key', 'notme');
+      let promise = zk.activate('key', 'notme');
       return assert.isRejected(promise)
         .then(function(error) {
           assert.equal(error, '`notme` is not a valid revision key');
@@ -306,21 +330,21 @@ describe('zookeeper plugin', function() {
     });
 
     it('resolves and sets the current revision to the revision key provided', function() {
-      var hash = {
+      let hash = {
         '/key': '1',
         '/key/revisions/1': 1,
         '/key/revisions/2': 2,
         '/key/revisions/3': 3
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.activate('key', '2');
+      let promise = zk.activate('key', '2');
       return assert.isFulfilled(promise)
         .then(function(activatedKey) {
           assert.equal(activatedKey, '2');
@@ -330,20 +354,20 @@ describe('zookeeper plugin', function() {
 
   describe('#fetchRevisions', function() {
     it('lists the last existing revisions', function() {
-      var hash = {
+      let hash = {
         '/key/revisions/1': '1',
         '/key/revisions/2': '2',
         '/key/revisions/3': '3'
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.fetchRevisions('key');
+      let promise = zk.fetchRevisions('key');
       return assert.isFulfilled(promise)
         .then(function(result) {
           assert.deepEqual(result, [
@@ -367,21 +391,21 @@ describe('zookeeper plugin', function() {
     });
 
     it('lists the last existing revisions and marks the active one', function() {
-      var hash = {
+      let hash = {
         '/key': '2',
         '/key/revisions/1': '1',
         '/key/revisions/2': '2',
         '/key/revisions/3': '3'
       };
 
-      var zk = new Zookeeper({}, FakeZookeeper.extend({
+      let zk = new Zookeeper({}, FakeZookeeper.extend({
         init: function() {
           this._super.apply(this, arguments);
           this._hash = hash;
         }
       }));
 
-      var promise = zk.fetchRevisions('key');
+      let promise = zk.fetchRevisions('key');
       return assert.isFulfilled(promise)
         .then(function(result) {
           assert.deepEqual(result, [


### PR DESCRIPTION
This moves from `zookeeper` to `node-zookeeper-client` so that the library no longer depends on the C binding. (It was always a headache).