### PR TITLE
Remove ember-cli promise in favor of RSVP

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 let DeployPluginBase = require('ember-cli-deploy-plugin');
 let path = require('path');
 let fs = require('fs');
-let Promise = require('ember-cli/lib/ext/promise');
+let RSVP = require('rsvp');
 let denodeify = require('rsvp').denodeify;
 let readFile  = denodeify(fs.readFile);
 
@@ -68,7 +68,7 @@ module.exports = {
               .then(function(key) {
                 return paths.push({ zkKey: key });
               });
-          }, Promise.resolve())
+          }, RSVP.resolve())
           .then(zkDeployClient.trimRecentUploads.bind(zkDeployClient, keyPrefix, revisionKey))
           .then(function() {
             return paths;
@@ -80,7 +80,7 @@ module.exports = {
         let zkDeployClient = this.readConfig('zookeeperDeployClient');
         let keyPrefix = this.readConfig('keyPrefix');
 
-        return Promise.resolve(zkDeployClient.activeRevision(keyPrefix))
+        return RSVP.resolve(zkDeployClient.activeRevision(keyPrefix))
           .then(function(revisionKey) {
             return {
               revisionData: {
@@ -97,7 +97,7 @@ module.exports = {
         let keyPrefix = this.readConfig('keyPrefix');
 
         this.log('Activating revision `' + revisionKey + '`', { verbose: true });
-        return Promise.resolve(zkDeployClient.activate(keyPrefix, revisionKey))
+        return RSVP.resolve(zkDeployClient.activate(keyPrefix, revisionKey))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function(){
             return {
@@ -121,7 +121,7 @@ module.exports = {
         let keyPrefix = this.readConfig('keyPrefix');
 
         this.log('Listing revision for key: `' + keyPrefix + '`');
-        return Promise.resolve(zkDeployClient.fetchRevisions(keyPrefix))
+        return RSVP.resolve(zkDeployClient.fetchRevisions(keyPrefix))
           .then(function(revisions) {
             return { revisions: revisions };
           })
@@ -135,7 +135,7 @@ module.exports = {
           { verbose: true }
         );
 
-        return Promise.resolve()
+        return RSVP.resolve()
           .then(this._readFileContents.bind(this, filePath))
           .then(zkDeployClient.upload.bind(zkDeployClient, keyPrefix, revisionKey, fileName))
           .then(this._uploadSuccessMessage.bind(this));
@@ -150,12 +150,12 @@ module.exports = {
 
       _uploadSuccessMessage: function(key) {
         this.log('Uploaded with key `' + key + '`', { verbose: true });
-        return Promise.resolve(key);
+        return RSVP.resolve(key);
       },
 
       _errorMessage: function(error) {
         this.log(error, { color: 'red' });
-        return Promise.reject(error);
+        return RSVP.reject(error);
       }
     });
 

--- a/lib/zookeeper-promised.js
+++ b/lib/zookeeper-promised.js
@@ -1,5 +1,5 @@
 const CoreObject = require('core-object');
-const Promise = require('ember-cli/lib/ext/promise');
+const RSVP = require('rsvp');
 const ZKError = require('./zookeeper-error');
 const Buffer = require('buffer').Buffer;
 
@@ -20,7 +20,7 @@ module.exports = CoreObject.extend({
       host_order_deterministic: true
     });
 
-    this.connection = new Promise(function(resolve, reject) {
+    this.connection = new RSVP.Promise(function(resolve, reject) {
       let timeout = setTimeout(function() {
         zk.close();
         reject('Timed out trying to connect to ZooKeeper');
@@ -152,7 +152,7 @@ module.exports = CoreObject.extend({
 
   _promisify(cb) {
     return this.connect().then((zk) => {
-      return new Promise((resolve, reject) => {
+      return new RSVP.Promise((resolve, reject) => {
         cb(zk, resolve, reject);
       });
     });

--- a/lib/zookeeper-proxy.js
+++ b/lib/zookeeper-proxy.js
@@ -1,5 +1,5 @@
 let CoreObject = require('core-object');
-let Promise = require('ember-cli/lib/ext/promise');
+let RSVP = require('rsvp');
 let ZKPromised = require('./zookeeper-promised');
 
 module.exports = CoreObject.extend({
@@ -19,7 +19,7 @@ module.exports = CoreObject.extend({
     return this._createIfNotExist(key)
       .catch(function(err) {
         client.close();
-        return Promise.reject(err);
+        return RSVP.reject(err);
       });
   },
 
@@ -74,7 +74,7 @@ function proxyMethod(methodName, ...outerArgs) {
       })
       .catch(function(err) {
         client.close();
-        return Promise.reject(err);
+        return RSVP.reject(err);
       })
   };
 }

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -1,6 +1,6 @@
 let CoreObject = require('core-object');
 let path = require('path');
-let Promise = require('ember-cli/lib/ext/promise');
+let RSVP = require('rsvp');
 let zkProxy = require('./zookeeper-proxy');
 let REVISION_PATH = 'revisions';
 
@@ -8,7 +8,7 @@ module.exports = CoreObject.extend({
   init(options, lib) {
     this._super();
     this.options = options;
-    
+
     this._client = new zkProxy({
       connect: options.connect,
       connectionTimeout: options.connectionTimeout,
@@ -33,7 +33,7 @@ module.exports = CoreObject.extend({
     let revisionKey = args[0] || 'default';
     let zkKey = makePath(keyPrefix, revisionKey, fileName);
 
-    return Promise.resolve()
+    return RSVP.Promise.resolve()
       .then(this._createMissingParentPaths.bind(this, [keyPrefix, revisionKey]))
       .then(this._rejectIfKeyExists.bind(this, zkKey))
       .then(this._upload.bind(this, zkKey, value))
@@ -43,12 +43,12 @@ module.exports = CoreObject.extend({
   },
   trimRecentUploads(keyPrefix, revisionKey = 'default') {
     let maxEntries = this._maxNumberOfRecentUploads;
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(this._updateRecentUploadsList.bind(this, keyPrefix, revisionKey))
       .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries));
   },
   activate(keyPrefix, revisionKey) {
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(this._listRevisions.bind(this, keyPrefix))
       .then(this._validateRevisionKey.bind(this, revisionKey))
       .then(this._activateRevisionKey.bind(this, keyPrefix, revisionKey))
@@ -57,7 +57,7 @@ module.exports = CoreObject.extend({
   activeRevision(keyPrefix) {
     let path = makePath(keyPrefix);
     let client = this._client;
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(function() {
         return client.get(path);
       })
@@ -74,9 +74,9 @@ module.exports = CoreObject.extend({
     let self = this;
     let client = this._client;
 
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(function() {
-        return Promise.hash({
+        return RSVP.hash({
           revisions: self._listRevisions(keyPrefix),
           current: self.activeRevision(keyPrefix)
         });
@@ -93,17 +93,17 @@ module.exports = CoreObject.extend({
   _listRevisions(keyPrefix) {
     let path = makePath(keyPrefix, REVISION_PATH);
     let self = this;
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(this._client.getChildren.bind(this._client, path))
       .then(function(res) {
-        return Promise.all(res.children.map(function(revision) {
+        return RSVP.all(res.children.map(function(revision) {
           return self._getRevisionData(keyPrefix, revision);
         }));
       });
   },
   _getRevisionData(keyPrefix, revision) {
     let path = makePath(keyPrefix, REVISION_PATH, revision);
-    return Promise.resolve()
+    return RSVP.resolve()
       .then(this._client.get.bind(this._client, path))
       .then(function(res) {
         return {
@@ -122,19 +122,19 @@ module.exports = CoreObject.extend({
       return promise.then(function() {
         return client.createIfNotExists(key);
       });
-    }, Promise.resolve()).then((res) => res);
+    }, RSVP.resolve()).then((res) => res);
   },
 
   _rejectIfKeyExists(zkKey) {
     let self = this;
     let allowOverwrite = !!this._allowOverwrite;
-    let promise = Promise.resolve();
+    let promise = RSVP.resolve();
 
     if (!allowOverwrite) {
       return promise.then(function() {
         return self._exists(zkKey);
       }).then(function(exists) {
-        return exists ? Promise.reject('Value already exists for key: ' + zkKey) : Promise.resolve();
+        return exists ? RSVP.reject('Value already exists for key: ' + zkKey) : RSVP.resolve();
       });
     }
 
@@ -164,7 +164,7 @@ module.exports = CoreObject.extend({
     // Delete the children of this path and itself.
     let client = this._client;
     return client.getChildren(path).then(function(res) {
-      return Promise.all(res.children.map(function(child) {
+      return RSVP.all(res.children.map(function(child) {
         return client.delete(makePath(path, child));
       }));
     }).then(function() {
@@ -178,11 +178,11 @@ module.exports = CoreObject.extend({
 
     return this._fetchRevisions(keyPrefix).then(function(results) {
       // Get all the revisions.
-      return Promise.all(results.filter(function(revision) {
+      return RSVP.all(results.filter(function(revision) {
         return !revision.active;
       }).map(function(revision) {
         let path = makePath(keyPrefix, REVISION_PATH, revision.revision);
-        return Promise.hash({
+        return RSVP.hash({
           clientData: client.get(path),
           revision: revision,
           path: path
@@ -193,13 +193,13 @@ module.exports = CoreObject.extend({
       revisionsData.sort(function(a, b) {
         return a.clientData.data > b.clientData.data ? -1 : 1;
       });
-      
+
       // Get the oldest items beyond the maximum number of entries.
       let revisionsToRemove = revisionsData.slice(maxEntries);
 
-      return Promise.all(revisionsToRemove.map(function(revisionData) {
+      return RSVP.all(revisionsToRemove.map(function(revisionData) {
         let revision = revisionData.revision.revision;
-        return Promise.all([
+        return RSVP.all([
           client.delete(revisionData.path),
           self._deleteChildrenAndSelf(makePath(keyPrefix, revision))
         ]);
@@ -210,7 +210,7 @@ module.exports = CoreObject.extend({
     let revisionsList = revisions.map(function(revision) {
       return revision.revision;
     });
-    return revisionsList.indexOf(revisionKey) > -1 ? Promise.resolve() : Promise.reject('`' + revisionKey + '` is not a valid revision key');
+    return revisionsList.indexOf(revisionKey) > -1 ? RSVP.resolve() : RSVP.reject('`' + revisionKey + '` is not a valid revision key');
   },
   _activateRevisionKey(keyPrefix, revision) {
     let path = makePath(keyPrefix);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/RavelLaw/ember-cli-deploy-zookeeper.git"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "author": "",
   "license": "MIT",

--- a/tests/helpers/fake-zk-client.js
+++ b/tests/helpers/fake-zk-client.js
@@ -1,5 +1,4 @@
 const CoreObject = require('core-object');
-const Promise = require('ember-cli/lib/ext/promise');
 const ZKError = require('../../lib/zookeeper-error');
 const Buffer = require('buffer').Buffer;
 
@@ -19,7 +18,7 @@ const FakeZookeeperClient = CoreObject.extend({
   connect() {
     const cb = this._callbacks.connected;
     this.isConnected = true;
-    
+
     return next(function() {
       cb && cb();
     }.bind(this), 'connecting');

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,6 +1,5 @@
 'use strict';
-
-let Promise = require('ember-cli/lib/ext/promise');
+let RSVP = require('rsvp');
 let assert  = require('../helpers/assert');
 let FakeZookeeper = require('../helpers/fake-zk-client');
 
@@ -376,7 +375,7 @@ describe('ember-cli-deploy-zookeeper', function() {
             zookeeperDeployClient: function(context){
               return {
                 activate: function() {
-                  return Promise.reject('some-error');
+                  return RSVP.reject('some-error');
                 }
               };
             }
@@ -413,7 +412,7 @@ describe('ember-cli-deploy-zookeeper', function() {
             zookeeperDeployClient: function(context) {
               return {
                 activeRevision: function() {
-                  return Promise.resolve('active-revision');
+                  return RSVP.resolve('active-revision');
                 }
               };
             }
@@ -527,7 +526,7 @@ describe('ember-cli-deploy-zookeeper', function() {
             zookeeperDeployClient: function(context) {
               return {
                 fetchRevisions: function(keyPrefix, revisionKey) {
-                  return Promise.resolve([{
+                  return RSVP.resolve([{
                     revision: 'a',
                     active: false
                   }]);

--- a/tests/unit/lib/zookeeper-nodetest.js
+++ b/tests/unit/lib/zookeeper-nodetest.js
@@ -1,7 +1,6 @@
 'use strict';
 let FakeZookeeper = require('../../helpers/fake-zk-client');
 let ZKError = require('../../../lib/zookeeper-error');
-let Promise = require('ember-cli/lib/ext/promise');
 let assert  = require('../../helpers/assert');
 
 describe('zookeeper plugin', function() {

--- a/tests/unit/lib/zookeeper-proxy-nodetest.js
+++ b/tests/unit/lib/zookeeper-proxy-nodetest.js
@@ -1,6 +1,6 @@
 'use strict';
 const ZookeeperProxy = require('../../../lib/zookeeper-proxy');
-const Promise = require('ember-cli/lib/ext/promise');
+const RSVP = require('rsvp');
 const assert  = require('../../helpers/assert');
 const CoreObject = require('core-object');
 
@@ -13,15 +13,15 @@ const ClientStub = CoreObject.extend({
   once(event, cb) {
     this._callbacks[event] = cb;
   },
-  connect() { 
-    this._callbacks.connected(); 
+  connect() {
+    this._callbacks.connected();
   },
   getData(p, cb) { cb(null, 'get', null); },
   getChildren(p, cb) { cb(null, ['getChildren']); },
   exists(p, cb) { cb(null, null); },
   remove(p, v, cb) { cb(null); },
   setData(p, d, cb) { cb(null, 'set'); },
-  close() { return Promise.resolve('close'); },
+  close() { return RSVP.resolve('close'); },
   create(p, cb) { cb(null, p); }
 });
 
@@ -168,7 +168,7 @@ describe('zookeeper proxy', function() {
         }
       }));
 
-      return assert.isFulfilled(Promise.all([
+      return assert.isFulfilled(RSVP.all([
           proxy.set('/test'),
           proxy.set('/test')
         ]))
@@ -189,7 +189,7 @@ describe('zookeeper proxy', function() {
         }
       }));
 
-      return assert.isFulfilled(Promise.all([
+      return assert.isFulfilled(RSVP.all([
           proxy.set('/test'),
           proxy.set('/test')
         ]))


### PR DESCRIPTION
This uses RSVP in favor of the built-in promise library from Ember-CLI. This removes deprecation messages. 